### PR TITLE
Hotfix: EmbedOne Unserializer

### DIFF
--- a/lib/Zoop/Shard/Serializer/Serializer.php
+++ b/lib/Zoop/Shard/Serializer/Serializer.php
@@ -154,7 +154,7 @@ class Serializer implements ServiceLocatorAwareInterface, ModelManagerAwareInter
     {
         $mapping = $metadata->fieldMappings[$field];
         $serializedDocument = null;
-        
+
         if (isset($mapping['embedded'])) {
             if (is_array($value)) {
                 $serializedDocument = $this->applySerializeMetadataToArray($value, $mapping['targetDocument']);
@@ -178,7 +178,7 @@ class Serializer implements ServiceLocatorAwareInterface, ModelManagerAwareInter
             $serializedDocument[$discriminatorField] =
                 array_search(get_class($value), $mapping['discriminatorMap']);
         }
-        
+
         return $serializedDocument;
     }
 

--- a/lib/Zoop/Shard/Serializer/Unserializer.php
+++ b/lib/Zoop/Shard/Serializer/Unserializer.php
@@ -107,7 +107,7 @@ class Unserializer implements ServiceLocatorAwareInterface, ModelManagerAwareInt
         $mode = self::UNSERIALIZE_PATCH
     ) {
         $metadata = $this->modelManager->getClassMetadata($class);
-        
+
         // Check for discrimnator and discriminator field in data
         if (isset($metadata->discriminatorField) && isset($data[$metadata->discriminatorField['fieldName']])) {
             $metadata = $this->modelManager->getClassMetadata(
@@ -172,12 +172,12 @@ class Unserializer implements ServiceLocatorAwareInterface, ModelManagerAwareInt
         if (is_string($data[$field])) {
             $document = $this->modelManager->getRepository($metadata->name)->find($data[$field]);
         }
-        
+
         if (isset($mapping['discriminatorMap'])) {
             $discriminatorField = isset($mapping['discriminatorField']) ?
                     $mapping['discriminatorField'] :
                     '_doctrine_class_name';
-            
+
             $targetClass = $mapping['discriminatorMap'][$data[$field][$discriminatorField]];
         } else {
             $targetClass = $metadata->getAssociationTargetClass($field);

--- a/lib/Zoop/Shard/Serializer/Unserializer.php
+++ b/lib/Zoop/Shard/Serializer/Unserializer.php
@@ -107,7 +107,7 @@ class Unserializer implements ServiceLocatorAwareInterface, ModelManagerAwareInt
         $mode = self::UNSERIALIZE_PATCH
     ) {
         $metadata = $this->modelManager->getClassMetadata($class);
-
+        
         // Check for discrimnator and discriminator field in data
         if (isset($metadata->discriminatorField) && isset($data[$metadata->discriminatorField['fieldName']])) {
             $metadata = $this->modelManager->getClassMetadata(
@@ -172,9 +172,13 @@ class Unserializer implements ServiceLocatorAwareInterface, ModelManagerAwareInt
         if (is_string($data[$field])) {
             $document = $this->modelManager->getRepository($metadata->name)->find($data[$field]);
         }
-
-        if (isset($mapping['discriminatorField']) && isset($data[$field][$mapping['discriminatorField']])) {
-            $targetClass = $mapping['discriminatorMap'][$data[$field][$mapping['discriminatorField']]];
+        
+        if (isset($mapping['discriminatorMap'])) {
+            $discriminatorField = isset($mapping['discriminatorField']) ?
+                    $mapping['discriminatorField'] :
+                    '_doctrine_class_name';
+            
+            $targetClass = $mapping['discriminatorMap'][$data[$field][$discriminatorField]];
         } else {
             $targetClass = $metadata->getAssociationTargetClass($field);
         }

--- a/tests/Zoop/Shard/Test/Serializer/SerializerDiscriminatorTest.php
+++ b/tests/Zoop/Shard/Test/Serializer/SerializerDiscriminatorTest.php
@@ -5,6 +5,7 @@ namespace Zoop\Shard\Test\Serializer;
 use Doctrine\Common\Collections\ArrayCollection;
 use Zoop\Shard\Manifest;
 use Zoop\Shard\Test\BaseTest;
+use Zoop\Shard\Test\Serializer\TestAsset\Document\EmbeddedApple;
 use Zoop\Shard\Test\Serializer\TestAsset\Document\Apple;
 use Zoop\Shard\Test\Serializer\TestAsset\Document\FruitBowl;
 use Zoop\Shard\Test\Serializer\TestAsset\Document\Orange;
@@ -14,18 +15,19 @@ use Zoop\Shard\Test\Serializer\TestAsset\Document\Female;
 
 class SerializerDiscriminatorTest extends BaseTest
 {
+
     public function setUp()
     {
         $manifest = new Manifest(
-            [
-                'models' => [
-                    __NAMESPACE__ . '\TestAsset\Document' => __DIR__ . '/TestAsset/Document'
-                ],
-                'extension_configs' => [
-                    'extension.serializer' => true,
-                    'extension.odmcore' => true
-                ],
-            ]
+                [
+            'models' => [
+                __NAMESPACE__ . '\TestAsset\Document' => __DIR__ . '/TestAsset/Document'
+            ],
+            'extension_configs' => [
+                'extension.serializer' => true,
+                'extension.odmcore' => true
+            ],
+                ]
         );
 
         $this->documentManager = $manifest->getServiceManager()->get('modelmanager');
@@ -69,8 +71,7 @@ class SerializerDiscriminatorTest extends BaseTest
         );
 
         $testDoc = $this->unserializer->fromArray(
-            $data,
-            'Zoop\Shard\Test\Serializer\TestAsset\Document\Fruit'
+                $data, 'Zoop\Shard\Test\Serializer\TestAsset\Document\Fruit'
         );
 
         $this->assertTrue($testDoc instanceof Apple);
@@ -95,8 +96,7 @@ class SerializerDiscriminatorTest extends BaseTest
         );
 
         $testDoc = $this->unserializer->fromArray(
-            $data,
-            'Zoop\Shard\Test\Serializer\TestAsset\Document\FruitBowl'
+                $data, 'Zoop\Shard\Test\Serializer\TestAsset\Document\FruitBowl'
         );
 
         $this->assertTrue($testDoc instanceof FruitBowl);
@@ -137,8 +137,8 @@ class SerializerDiscriminatorTest extends BaseTest
     public function testSerializeSingleEmbeddedDiscriminator()
     {
 
-        $apple = new Apple();
-        $apple->setVariety('granny smith');
+        $apple = new EmbeddedApple();
+        $apple->setColor('red');
 
         $fruitBowl = new FruitBowl;
         $fruitBowl->setEmbeddedSingleFruit($apple);
@@ -146,8 +146,7 @@ class SerializerDiscriminatorTest extends BaseTest
         $correct = array(
             'embeddedSingleFruit' => [
                 '_doctrine_class_name' => 'apple',
-                'variety' => 'granny smith',
-                'type' => 'apple'
+                'color' => 'red'
             ]
         );
 
@@ -155,26 +154,22 @@ class SerializerDiscriminatorTest extends BaseTest
 
         $this->assertEquals($correct, $array);
     }
-    
+
     public function testUnserializeSingleEmbeddedDiscriminator()
     {
         $data = array(
             'embeddedSingleFruit' => [
-                [
-                    'type' => 'apple',
-                    'variety' => 'red delicious',
-                    'color' => 'red'
-                ]
+                '_doctrine_class_name' => 'apple',
+                'color' => 'red'
             ]
         );
 
         $testDoc = $this->unserializer->fromArray(
-            $data,
-            'Zoop\Shard\Test\Serializer\TestAsset\Document\FruitBowl'
+                $data, 'Zoop\Shard\Test\Serializer\TestAsset\Document\FruitBowl'
         );
 
         $this->assertTrue($testDoc instanceof FruitBowl);
-        $this->assertTrue($testDoc->getEmbeddedFruit() instanceof Apple);
+        $this->assertTrue($testDoc->getEmbeddedFruit() instanceof EmbeddedApple);
     }
 
     public function testUnserializeReferenceDiscriminator()
@@ -195,8 +190,7 @@ class SerializerDiscriminatorTest extends BaseTest
         );
 
         $testDoc = $this->unserializer->fromArray(
-            $data,
-            'Zoop\Shard\Test\Serializer\TestAsset\Document\FruitBowl'
+                $data, 'Zoop\Shard\Test\Serializer\TestAsset\Document\FruitBowl'
         );
 
         $this->assertTrue($testDoc instanceof FruitBowl);
@@ -223,8 +217,7 @@ class SerializerDiscriminatorTest extends BaseTest
         );
 
         $testDoc = $this->unserializer->fromArray(
-            $data,
-            'Zoop\Shard\Test\Serializer\TestAsset\Document\FruitBowl'
+                $data, 'Zoop\Shard\Test\Serializer\TestAsset\Document\FruitBowl'
         );
 
         $this->assertTrue($testDoc instanceof FruitBowl);
@@ -254,8 +247,7 @@ class SerializerDiscriminatorTest extends BaseTest
         );
 
         $testDoc = $this->unserializer->fromArray(
-            $data,
-            'Zoop\Shard\Test\Serializer\TestAsset\Document\FruitBowl'
+                $data, 'Zoop\Shard\Test\Serializer\TestAsset\Document\FruitBowl'
         );
 
         $this->assertTrue($testDoc instanceof FruitBowl);
@@ -317,8 +309,7 @@ class SerializerDiscriminatorTest extends BaseTest
         );
 
         $testDoc = $this->unserializer->fromArray(
-            $data,
-            'Zoop\Shard\Test\Serializer\TestAsset\Document\Family'
+                $data, 'Zoop\Shard\Test\Serializer\TestAsset\Document\Family'
         );
 
         $this->assertTrue($testDoc instanceof Family);
@@ -377,8 +368,7 @@ class SerializerDiscriminatorTest extends BaseTest
         );
 
         $testDoc = $this->unserializer->fromArray(
-            $data,
-            'Zoop\Shard\Test\Serializer\TestAsset\Document\Family'
+                $data, 'Zoop\Shard\Test\Serializer\TestAsset\Document\Family'
         );
 
         $this->assertTrue($testDoc instanceof Family);
@@ -424,4 +414,5 @@ class SerializerDiscriminatorTest extends BaseTest
 
         $this->assertEquals($correct, $array);
     }
+
 }

--- a/tests/Zoop/Shard/Test/Serializer/SerializerDiscriminatorTest.php
+++ b/tests/Zoop/Shard/Test/Serializer/SerializerDiscriminatorTest.php
@@ -202,46 +202,8 @@ class SerializerDiscriminatorTest extends BaseTest
         $testDoc = $this->unserializer->fromArray(
                 $data, 'Zoop\Shard\Test\Serializer\TestAsset\Document\AccessControl\Administrators'
         );
-        die(var_dump($testDoc));
+        
         $this->assertTrue($testDoc instanceof AccessControl\Administrators);
-    }
-
-    public function testSerializeSingleEmbeddedDiscriminator()
-    {
-
-        $apple = new EmbeddedApple();
-        $apple->setColor('red');
-
-        $fruitBowl = new FruitBowl;
-        $fruitBowl->setEmbeddedSingleFruit($apple);
-
-        $correct = array(
-            'embeddedSingleFruit' => [
-                '_doctrine_class_name' => 'apple',
-                'color' => 'red'
-            ]
-        );
-
-        $array = $this->serializer->toArray($fruitBowl);
-
-        $this->assertEquals($correct, $array);
-    }
-
-    public function testUnserializeSingleEmbeddedDiscriminator()
-    {
-        $data = array(
-            'embeddedSingleFruit' => [
-                '_doctrine_class_name' => 'apple',
-                'color' => 'red'
-            ]
-        );
-
-        $testDoc = $this->unserializer->fromArray(
-                $data, 'Zoop\Shard\Test\Serializer\TestAsset\Document\FruitBowl'
-        );
-
-        $this->assertTrue($testDoc instanceof FruitBowl);
-        $this->assertTrue($testDoc->getEmbeddedFruit() instanceof EmbeddedApple);
     }
 
     public function testUnserializeReferenceDiscriminator()

--- a/tests/Zoop/Shard/Test/Serializer/SerializerDiscriminatorTest.php
+++ b/tests/Zoop/Shard/Test/Serializer/SerializerDiscriminatorTest.php
@@ -16,11 +16,9 @@ use Zoop\Shard\Test\Serializer\TestAsset\Document\Female;
 
 class SerializerDiscriminatorTest extends BaseTest
 {
-
     public function setUp()
     {
-        $manifest = new Manifest(
-                [
+        $manifest = new Manifest([
             'models' => [
                 __NAMESPACE__ . '\TestAsset\Document' => __DIR__ . '/TestAsset/Document'
             ],
@@ -28,8 +26,7 @@ class SerializerDiscriminatorTest extends BaseTest
                 'extension.serializer' => true,
                 'extension.odmcore' => true
             ],
-                ]
-        );
+        ]);
 
         $this->documentManager = $manifest->getServiceManager()->get('modelmanager');
         $this->serializer = $manifest->getServiceManager()->get('serializer');
@@ -72,7 +69,8 @@ class SerializerDiscriminatorTest extends BaseTest
         );
 
         $testDoc = $this->unserializer->fromArray(
-                $data, 'Zoop\Shard\Test\Serializer\TestAsset\Document\Fruit'
+            $data,
+            'Zoop\Shard\Test\Serializer\TestAsset\Document\Fruit'
         );
 
         $this->assertTrue($testDoc instanceof Apple);
@@ -97,7 +95,8 @@ class SerializerDiscriminatorTest extends BaseTest
         );
 
         $testDoc = $this->unserializer->fromArray(
-                $data, 'Zoop\Shard\Test\Serializer\TestAsset\Document\FruitBowl'
+            $data,
+            'Zoop\Shard\Test\Serializer\TestAsset\Document\FruitBowl'
         );
 
         $this->assertTrue($testDoc instanceof FruitBowl);
@@ -200,9 +199,10 @@ class SerializerDiscriminatorTest extends BaseTest
         );
 
         $testDoc = $this->unserializer->fromArray(
-                $data, 'Zoop\Shard\Test\Serializer\TestAsset\Document\AccessControl\Administrators'
+            $data,
+            'Zoop\Shard\Test\Serializer\TestAsset\Document\AccessControl\Administrators'
         );
-        
+
         $this->assertTrue($testDoc instanceof AccessControl\Administrators);
     }
 
@@ -224,7 +224,8 @@ class SerializerDiscriminatorTest extends BaseTest
         );
 
         $testDoc = $this->unserializer->fromArray(
-                $data, 'Zoop\Shard\Test\Serializer\TestAsset\Document\FruitBowl'
+            $data,
+            'Zoop\Shard\Test\Serializer\TestAsset\Document\FruitBowl'
         );
 
         $this->assertTrue($testDoc instanceof FruitBowl);
@@ -251,7 +252,8 @@ class SerializerDiscriminatorTest extends BaseTest
         );
 
         $testDoc = $this->unserializer->fromArray(
-                $data, 'Zoop\Shard\Test\Serializer\TestAsset\Document\FruitBowl'
+            $data,
+            'Zoop\Shard\Test\Serializer\TestAsset\Document\FruitBowl'
         );
 
         $this->assertTrue($testDoc instanceof FruitBowl);
@@ -281,7 +283,8 @@ class SerializerDiscriminatorTest extends BaseTest
         );
 
         $testDoc = $this->unserializer->fromArray(
-                $data, 'Zoop\Shard\Test\Serializer\TestAsset\Document\FruitBowl'
+            $data,
+            'Zoop\Shard\Test\Serializer\TestAsset\Document\FruitBowl'
         );
 
         $this->assertTrue($testDoc instanceof FruitBowl);
@@ -343,7 +346,8 @@ class SerializerDiscriminatorTest extends BaseTest
         );
 
         $testDoc = $this->unserializer->fromArray(
-                $data, 'Zoop\Shard\Test\Serializer\TestAsset\Document\Family'
+            $data,
+            'Zoop\Shard\Test\Serializer\TestAsset\Document\Family'
         );
 
         $this->assertTrue($testDoc instanceof Family);
@@ -402,7 +406,8 @@ class SerializerDiscriminatorTest extends BaseTest
         );
 
         $testDoc = $this->unserializer->fromArray(
-                $data, 'Zoop\Shard\Test\Serializer\TestAsset\Document\Family'
+            $data,
+            'Zoop\Shard\Test\Serializer\TestAsset\Document\Family'
         );
 
         $this->assertTrue($testDoc instanceof Family);
@@ -448,5 +453,4 @@ class SerializerDiscriminatorTest extends BaseTest
 
         $this->assertEquals($correct, $array);
     }
-
 }

--- a/tests/Zoop/Shard/Test/Serializer/SerializerDiscriminatorTest.php
+++ b/tests/Zoop/Shard/Test/Serializer/SerializerDiscriminatorTest.php
@@ -155,6 +155,27 @@ class SerializerDiscriminatorTest extends BaseTest
 
         $this->assertEquals($correct, $array);
     }
+    
+    public function testUnserializeSingleEmbeddedDiscriminator()
+    {
+        $data = array(
+            'embeddedSingleFruit' => [
+                [
+                    'type' => 'apple',
+                    'variety' => 'red delicious',
+                    'color' => 'red'
+                ]
+            ]
+        );
+
+        $testDoc = $this->unserializer->fromArray(
+            $data,
+            'Zoop\Shard\Test\Serializer\TestAsset\Document\FruitBowl'
+        );
+
+        $this->assertTrue($testDoc instanceof FruitBowl);
+        $this->assertTrue($testDoc->getEmbeddedFruit() instanceof Apple);
+    }
 
     public function testUnserializeReferenceDiscriminator()
     {

--- a/tests/Zoop/Shard/Test/Serializer/SerializerEmbeddedTest.php
+++ b/tests/Zoop/Shard/Test/Serializer/SerializerEmbeddedTest.php
@@ -107,48 +107,4 @@ class SerializerEmbeddedTest extends BaseTest
         $this->assertTrue($testDoc->getEmbeddedSingleFruit() instanceof EmbeddedApple);
     }
 
-    public function testUnserializeUpdateEmbedMany()
-    {
-        //create the ACL group
-        $admins = new AccessControl\Administrators();
-
-        //create the users
-        $adminName = 'Admin Name';
-        $admin = new AccessControl\Administrator();
-        $admin->setName($adminName);
-
-        $super1Name = 'Super User 1 Name';
-        $super1 = new AccessControl\SuperUser();
-        $super1->setName($super1Name);
-
-        $super2Name = 'Super User 2 Name';
-        $super2 = new AccessControl\SuperUser();
-        $super2->setName($super2Name);
-
-        //add users to group and set the group owner
-        $admins->setOwner($admin);
-        $admins->addUser($super1);
-        $admins->addUser($super2);
-
-        //save the document first
-        $this->documentManager->persist($admin);
-        $this->documentManager->flush();
-
-        //get the serialized data
-        $data = $this->serializer->toArray($admins);
-
-        //change the number of users in the group back to 1
-        unset($data['users'][1]);
-
-        /* @var $mergedDoc AccessControl\Administrators */
-        $mergedDoc = $this->unserializer->fromArray(
-                $data, 'Zoop\Shard\Test\Serializer\TestAsset\Document\AccessControl\Administrators', $admins, Unserializer::UNSERIALIZE_UPDATE
-        );
-        $this->assertTrue($mergedDoc instanceof AccessControl\Administrators);
-        $this->assertCount(1, $mergedDoc->getUsers());
-
-        $this->documentManager->remove($admins);
-        $this->documentManager->flush();
-    }
-
 }

--- a/tests/Zoop/Shard/Test/Serializer/SerializerEmbeddedTest.php
+++ b/tests/Zoop/Shard/Test/Serializer/SerializerEmbeddedTest.php
@@ -11,11 +11,9 @@ use Zoop\Shard\Test\Serializer\TestAsset\Document\FruitBowl;
 
 class SerializerEmbeddedTest extends BaseTest
 {
-
     public function setUp()
     {
-        $manifest = new Manifest(
-                [
+        $manifest = new Manifest([
             'models' => [
                 __NAMESPACE__ . '\TestAsset\Document' => __DIR__ . '/TestAsset/Document'
             ],
@@ -23,8 +21,7 @@ class SerializerEmbeddedTest extends BaseTest
                 'extension.serializer' => true,
                 'extension.odmcore' => true
             ],
-                ]
-        );
+        ]);
 
         $this->documentManager = $manifest->getServiceManager()->get('modelmanager');
         $this->serializer = $manifest->getServiceManager()->get('serializer');
@@ -61,7 +58,8 @@ class SerializerEmbeddedTest extends BaseTest
 
         /* @var $testDoc FruitBowl */
         $testDoc = $this->unserializer->fromArray(
-                $data, 'Zoop\Shard\Test\Serializer\TestAsset\Document\FruitBowl'
+            $data,
+            'Zoop\Shard\Test\Serializer\TestAsset\Document\FruitBowl'
         );
 
         $this->assertTrue($testDoc instanceof FruitBowl);
@@ -100,11 +98,11 @@ class SerializerEmbeddedTest extends BaseTest
 
         /* @var $testDoc FruitBowl */
         $testDoc = $this->unserializer->fromArray(
-                $data, 'Zoop\Shard\Test\Serializer\TestAsset\Document\FruitBowl'
+            $data,
+            'Zoop\Shard\Test\Serializer\TestAsset\Document\FruitBowl'
         );
 
         $this->assertTrue($testDoc instanceof FruitBowl);
         $this->assertTrue($testDoc->getEmbeddedSingleFruit() instanceof EmbeddedApple);
     }
-
 }

--- a/tests/Zoop/Shard/Test/Serializer/SerializerEmbeddedTest.php
+++ b/tests/Zoop/Shard/Test/Serializer/SerializerEmbeddedTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Zoop\Shard\Test\Serializer;
+
+use Zoop\Shard\Manifest;
+use Zoop\Shard\Serializer\Unserializer;
+use Zoop\Shard\Test\BaseTest;
+use Zoop\Shard\Test\Serializer\TestAsset\Document\AccessControl;
+use Zoop\Shard\Test\Serializer\TestAsset\Document\EmbeddedApple;
+use Zoop\Shard\Test\Serializer\TestAsset\Document\FruitBowl;
+
+class SerializerEmbeddedTest extends BaseTest
+{
+
+    public function setUp()
+    {
+        $manifest = new Manifest(
+                [
+            'models' => [
+                __NAMESPACE__ . '\TestAsset\Document' => __DIR__ . '/TestAsset/Document'
+            ],
+            'extension_configs' => [
+                'extension.serializer' => true,
+                'extension.odmcore' => true
+            ],
+                ]
+        );
+
+        $this->documentManager = $manifest->getServiceManager()->get('modelmanager');
+        $this->serializer = $manifest->getServiceManager()->get('serializer');
+        $this->unserializer = $manifest->getServiceManager()->get('unserializer');
+    }
+
+    public function testSerializeEmbedOneTargetDocument()
+    {
+
+        $apple = new EmbeddedApple();
+        $apple->setColor('red');
+
+        $fruitBowl = new FruitBowl;
+        $fruitBowl->setEmbeddedSingleFruitTarget($apple);
+
+        $correct = [
+            'embeddedSingleFruitTarget' => [
+                'color' => 'red'
+            ]
+        ];
+
+        $array = $this->serializer->toArray($fruitBowl);
+        $this->assertEquals($correct, $array);
+    }
+
+    public function testUnserializeEmbedOneTargetDocument()
+    {
+        $data = [
+            'embeddedSingleFruitTarget' => [
+                '_doctrine_class_name' => 'apple',
+                'color' => 'red'
+            ]
+        ];
+
+        /* @var $testDoc FruitBowl */
+        $testDoc = $this->unserializer->fromArray(
+                $data, 'Zoop\Shard\Test\Serializer\TestAsset\Document\FruitBowl'
+        );
+
+        $this->assertTrue($testDoc instanceof FruitBowl);
+        $this->assertTrue($testDoc->getEmbeddedSingleFruitTarget() instanceof EmbeddedApple);
+    }
+
+    public function testSerializeEmbedOneDiscriminatorMap()
+    {
+
+        $apple = new EmbeddedApple();
+        $apple->setColor('red');
+
+        $fruitBowl = new FruitBowl;
+        $fruitBowl->setEmbeddedSingleFruit($apple);
+
+        $correct = [
+            'embeddedSingleFruit' => [
+                '_doctrine_class_name' => 'apple',
+                'color' => 'red'
+            ]
+        ];
+
+        $array = $this->serializer->toArray($fruitBowl);
+
+        $this->assertEquals($correct, $array);
+    }
+
+    public function testUnserializeEmbedOneDiscriminatorMap()
+    {
+        $data = [
+            'embeddedSingleFruit' => [
+                '_doctrine_class_name' => 'apple',
+                'color' => 'red'
+            ]
+        ];
+
+        /* @var $testDoc FruitBowl */
+        $testDoc = $this->unserializer->fromArray(
+                $data, 'Zoop\Shard\Test\Serializer\TestAsset\Document\FruitBowl'
+        );
+
+        $this->assertTrue($testDoc instanceof FruitBowl);
+        $this->assertTrue($testDoc->getEmbeddedSingleFruit() instanceof EmbeddedApple);
+    }
+
+    public function testUnserializeUpdateEmbedMany()
+    {
+        //create the ACL group
+        $admins = new AccessControl\Administrators();
+
+        //create the users
+        $adminName = 'Admin Name';
+        $admin = new AccessControl\Administrator();
+        $admin->setName($adminName);
+
+        $super1Name = 'Super User 1 Name';
+        $super1 = new AccessControl\SuperUser();
+        $super1->setName($super1Name);
+
+        $super2Name = 'Super User 2 Name';
+        $super2 = new AccessControl\SuperUser();
+        $super2->setName($super2Name);
+
+        //add users to group and set the group owner
+        $admins->setOwner($admin);
+        $admins->addUser($super1);
+        $admins->addUser($super2);
+
+        //save the document first
+        $this->documentManager->persist($admin);
+        $this->documentManager->flush();
+
+        //get the serialized data
+        $data = $this->serializer->toArray($admins);
+
+        //change the number of users in the group back to 1
+        unset($data['users'][1]);
+
+        /* @var $mergedDoc AccessControl\Administrators */
+        $mergedDoc = $this->unserializer->fromArray(
+                $data, 'Zoop\Shard\Test\Serializer\TestAsset\Document\AccessControl\Administrators', $admins, Unserializer::UNSERIALIZE_UPDATE
+        );
+        $this->assertTrue($mergedDoc instanceof AccessControl\Administrators);
+        $this->assertCount(1, $mergedDoc->getUsers());
+
+        $this->documentManager->remove($admins);
+        $this->documentManager->flush();
+    }
+
+}

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/AccessControl/AbstractGroup.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/AccessControl/AbstractGroup.php
@@ -16,7 +16,6 @@ use Zoop\Shard\Annotation\Annotations as Shard;
  */
 abstract class AbstractGroup
 {
-
     /**
      * @ODM\Id(strategy="UUID")
      */
@@ -45,5 +44,4 @@ abstract class AbstractGroup
     {
         $this->owner = $owner;
     }
-
 }

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/AccessControl/AbstractGroup.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/AccessControl/AbstractGroup.php
@@ -7,14 +7,14 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Zoop\Shard\Annotation\Annotations as Shard;
 
 /**
- * @ODM\Document(collection="Group")
+ * @ODM\Document(collection="AccessControlGroup")
  * @ODM\InheritanceType("SINGLE_COLLECTION")
  * @ODM\DiscriminatorMap({
  *     "Administrators" = "Zoop\Shard\Test\Serializer\TestAsset\Document\AccessControl\Administrators",
  *     "Guests"         = "Zoop\Shard\Test\Serializer\TestAsset\Document\AccessControl\Guests"
  * })
  */
-abstract class Group
+abstract class AbstractGroup
 {
 
     /**

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/AccessControl/AbstractUser.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/AccessControl/AbstractUser.php
@@ -8,7 +8,6 @@ use Zoop\Shard\Annotation\Annotations as Shard;
 
 abstract class AbstractUser
 {
-
     /**
      * @ODM\String
      */
@@ -23,5 +22,4 @@ abstract class AbstractUser
     {
         $this->name = $name;
     }
-
 }

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/AccessControl/AbstractUser.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/AccessControl/AbstractUser.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Zoop\Shard\Test\Serializer\TestAsset\Document\AccessControl;
+
+//Annotation imports
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Zoop\Shard\Annotation\Annotations as Shard;
+
+abstract class AbstractUser
+{
+
+    /**
+     * @ODM\String
+     */
+    protected $name;
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+}

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/AccessControl/Administrator.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/AccessControl/Administrator.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Zoop\Shard\Test\Serializer\TestAsset\Document\AccessControl;
+
+//Annotation imports
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Zoop\Shard\Annotation\Annotations as Shard;
+
+/**
+ * @ODM\EmbeddedDocument
+ */
+class Administrator extends AbstractUser implements UserInterface
+{
+    
+}

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/AccessControl/Administrators.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/AccessControl/Administrators.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Zoop\Shard\Test\Serializer\TestAsset\Document\AccessControl;
+
+//Annotation imports
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Zoop\Shard\Annotation\Annotations as Shard;
+
+/**
+ * @ODM\Document
+ */
+class Administrators extends Group
+{
+
+    /**
+     * @ODM\EmbedMany(
+     *     discriminatorMap={
+     *         "Administrator"  = "Zoop\Shard\Test\Serializer\TestAsset\Document\AccessControl\Administrator",
+     *         "SuperUser"      = "Zoop\Shard\Test\Serializer\TestAsset\Document\AccessControl\SuperUser"
+     *     }
+     * )
+     */
+    protected $users;
+
+    public function getUsers()
+    {
+        return $this->users;
+    }
+
+    public function setUsers($users)
+    {
+        $this->users = $users;
+    }
+
+    public function addUser(UserInterface $user)
+    {
+        $this->users[] = $user;
+    }
+
+}

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/AccessControl/Administrators.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/AccessControl/Administrators.php
@@ -9,7 +9,7 @@ use Zoop\Shard\Annotation\Annotations as Shard;
 /**
  * @ODM\Document
  */
-class Administrators extends Group
+class Administrators extends AbstractGroup
 {
 
     /**

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/AccessControl/Administrators.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/AccessControl/Administrators.php
@@ -11,7 +11,6 @@ use Zoop\Shard\Annotation\Annotations as Shard;
  */
 class Administrators extends AbstractGroup
 {
-
     /**
      * @ODM\EmbedMany(
      *     discriminatorMap={
@@ -36,5 +35,4 @@ class Administrators extends AbstractGroup
     {
         $this->users[] = $user;
     }
-
 }

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/AccessControl/Group.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/AccessControl/Group.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Zoop\Shard\Test\Serializer\TestAsset\Document\AccessControl;
+
+//Annotation imports
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Zoop\Shard\Annotation\Annotations as Shard;
+
+/**
+ * @ODM\Document(collection="Group")
+ * @ODM\InheritanceType("SINGLE_COLLECTION")
+ * @ODM\DiscriminatorMap({
+ *     "Administrators" = "Zoop\Shard\Test\Serializer\TestAsset\Document\AccessControl\Administrators",
+ *     "Guests"         = "Zoop\Shard\Test\Serializer\TestAsset\Document\AccessControl\Guests"
+ * })
+ */
+abstract class Group
+{
+
+    /**
+     * @ODM\Id(strategy="UUID")
+     */
+    protected $id;
+
+    /**
+     * @ODM\EmbedOne(
+     *     discriminatorMap={
+     *         "Administrator"  = "Zoop\Shard\Test\Serializer\TestAsset\Document\AccessControl\Administrator"
+     *     }
+     * )
+     */
+    protected $owner;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getOwner()
+    {
+        return $this->owner;
+    }
+
+    public function setOwner(Administrator $owner)
+    {
+        $this->owner = $owner;
+    }
+
+}

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/AccessControl/Guests.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/AccessControl/Guests.php
@@ -9,7 +9,7 @@ use Zoop\Shard\Annotation\Annotations as Shard;
 /**
  * @ODM\Document
  */
-class Guests extends Group
+class Guests extends AbstractGroup
 {
 
     /**

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/AccessControl/Guests.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/AccessControl/Guests.php
@@ -11,7 +11,6 @@ use Zoop\Shard\Annotation\Annotations as Shard;
  */
 class Guests extends AbstractGroup
 {
-
     /**
      * @ODM\EmbeddMany(
      *     discriminatorMap={
@@ -35,5 +34,4 @@ class Guests extends AbstractGroup
     {
         $this->users[] = $user;
     }
-
 }

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/AccessControl/Guests.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/AccessControl/Guests.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Zoop\Shard\Test\Serializer\TestAsset\Document\AccessControl;
+
+//Annotation imports
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Zoop\Shard\Annotation\Annotations as Shard;
+
+/**
+ * @ODM\Document
+ */
+class Guests extends Group
+{
+
+    /**
+     * @ODM\EmbeddMany(
+     *     discriminatorMap={
+     *         "Guest"      = "Zoop\Shard\Test\Serializer\TestAsset\Document\AccessControl\Guest"
+     *     }
+     * )
+     */
+    protected $users;
+
+    public function getUsers()
+    {
+        return $this->users;
+    }
+
+    public function setUsers($users)
+    {
+        $this->users = $users;
+    }
+
+    public function addUser(UserInterface $user)
+    {
+        $this->users[] = $user;
+    }
+
+}

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/AccessControl/SuperUser.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/AccessControl/SuperUser.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Zoop\Shard\Test\Serializer\TestAsset\Document\AccessControl;
+
+//Annotation imports
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Zoop\Shard\Annotation\Annotations as Shard;
+
+/**
+ * @ODM\EmbeddedDocument
+ */
+class SuperUser extends AbstractUser implements UserInterface
+{
+    
+}

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/AccessControl/UserInterface.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/AccessControl/UserInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Zoop\Shard\Test\Serializer\TestAsset\Document\AccessControl;
+
+interface UserInterface
+{
+
+    public function getName();
+
+    public function setName($name);
+}

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/AccessControl/UserInterface.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/AccessControl/UserInterface.php
@@ -4,8 +4,6 @@ namespace Zoop\Shard\Test\Serializer\TestAsset\Document\AccessControl;
 
 interface UserInterface
 {
-
     public function getName();
-
     public function setName($name);
 }

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/EmbeddedApple.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/EmbeddedApple.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Zoop\Shard\Test\Serializer\TestAsset\Document;
+
+//Annotation imports
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Zoop\Shard\Annotation\Annotations as Shard;
+
+/**
+ * @ODM\EmbeddedDocument
+ */
+class EmbeddedApple
+{
+
+    /**
+     *
+     * @ODM\String
+     */
+    protected $color;
+
+    public function getColor()
+    {
+        return $this->color;
+    }
+
+    public function setColor($color)
+    {
+        $this->color = $color;
+    }
+
+}

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/EmbeddedApple.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/EmbeddedApple.php
@@ -11,7 +11,6 @@ use Zoop\Shard\Annotation\Annotations as Shard;
  */
 class EmbeddedApple
 {
-
     /**
      *
      * @ODM\String
@@ -27,5 +26,4 @@ class EmbeddedApple
     {
         $this->color = $color;
     }
-
 }

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/EmbeddedOrange.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/EmbeddedOrange.php
@@ -11,7 +11,6 @@ use Zoop\Shard\Annotation\Annotations as Shard;
  */
 class EmbeddedOrange
 {
-
     /**
      *
      * @ODM\String
@@ -27,5 +26,4 @@ class EmbeddedOrange
     {
         $this->size = $size;
     }
-
 }

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/EmbeddedOrange.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/EmbeddedOrange.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Zoop\Shard\Test\Serializer\TestAsset\Document;
+
+//Annotation imports
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Zoop\Shard\Annotation\Annotations as Shard;
+
+/**
+ * @ODM\EmbeddedDocument
+ */
+class EmbeddedOrange
+{
+
+    /**
+     *
+     * @ODM\String
+     */
+    protected $size;
+
+    public function getSize()
+    {
+        return $this->size;
+    }
+
+    public function setSize($size)
+    {
+        $this->size = $size;
+    }
+
+}

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/FruitBowl.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/FruitBowl.php
@@ -12,7 +12,6 @@ use Zoop\Shard\Annotation\Annotations as Shard;
  */
 class FruitBowl
 {
-
     /**
      * @ODM\Id(strategy="UUID")
      */
@@ -133,5 +132,4 @@ class FruitBowl
         $this->embeddedFruit = new ArrayCollection();
         $this->referencedFruit = new ArrayCollection();
     }
-
 }

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/FruitBowl.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/FruitBowl.php
@@ -44,8 +44,8 @@ class FruitBowl
     /**
      * @ODM\EmbedOne(
      *     discriminatorMap={
-     *         "apple"="Zoop\Shard\Test\Serializer\TestAsset\Document\Apple",
-     *         "orange"="Zoop\Shard\Test\Serializer\TestAsset\Document\Orange"
+     *         "apple"="Zoop\Shard\Test\Serializer\TestAsset\Document\EmbeddedApple",
+     *         "orange"="Zoop\Shard\Test\Serializer\TestAsset\Document\EmbeddedOrange"
      *     }
      * )
      * @Shard\Serializer\Eager

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/FruitBowl.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/FruitBowl.php
@@ -3,7 +3,6 @@
 namespace Zoop\Shard\Test\Serializer\TestAsset\Document;
 
 use Doctrine\Common\Collections\ArrayCollection;
-
 //Annotation imports
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Zoop\Shard\Annotation\Annotations as Shard;
@@ -13,6 +12,7 @@ use Zoop\Shard\Annotation\Annotations as Shard;
  */
 class FruitBowl
 {
+
     /**
      * @ODM\Id(strategy="UUID")
      */
@@ -51,6 +51,14 @@ class FruitBowl
      * @Shard\Serializer\Eager
      */
     protected $embeddedSingleFruit;
+
+    /**
+     * @ODM\EmbedOne(
+     *     targetDocument="Zoop\Shard\Test\Serializer\TestAsset\Document\EmbeddedApple"
+     * )
+     * @Shard\Serializer\Eager
+     */
+    protected $embeddedSingleFruitTarget;
 
     /**
      * @ODM\ReferenceOne(
@@ -110,9 +118,20 @@ class FruitBowl
         $this->referencedSingleFruit = $referencedSingleFruit;
     }
 
+    public function getEmbeddedSingleFruitTarget()
+    {
+        return $this->embeddedSingleFruitTarget;
+    }
+
+    public function setEmbeddedSingleFruitTarget(EmbeddedApple $embeddedSingleFruitTarget)
+    {
+        $this->embeddedSingleFruitTarget = $embeddedSingleFruitTarget;
+    }
+
     public function __construct()
     {
         $this->embeddedFruit = new ArrayCollection();
         $this->referencedFruit = new ArrayCollection();
     }
+
 }


### PR DESCRIPTION
Fixes #17;

The following now works:
- Serialize and Unserialize EmbedOne with discriminatorMap
- Serialize and Unserialize EmbedOne with targetDocument
