### PR TITLE
Enhancement/merge extension config

### DIFF
--- a/lib/Zoop/Shard/Manifest.php
+++ b/lib/Zoop/Shard/Manifest.php
@@ -205,11 +205,9 @@ class Manifest extends AbstractExtension
     protected function setExtensionConfig($extension, $config)
     {
         foreach ($config as $key => $value) {
-            if ($key == 'default_db') {
-                $setter = 'set' . str_replace(' ', '', ucwords(str_replace('_', ' ', $key)));
-                if (method_exists($extension, $setter)) {
-                    $extension->{$setter}($value);
-                }
+            $setter = 'set' . str_replace(' ', '', ucwords(str_replace('_', ' ', $key)));
+            if (method_exists($extension, $setter)) {
+                $extension->{$setter}($value);
             }
         }
     }

--- a/tests/Zoop/Shard/Test/Core/ManifestConfigTest.php
+++ b/tests/Zoop/Shard/Test/Core/ManifestConfigTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Zoop\Shard\Test\Core;
+
+use Zoop\Shard\Manifest;
+use Zoop\Shard\Test\BaseTest;
+use Zoop\Shard\ODMCore\Extension as CoreExtension;
+
+class ManifestConfigTest extends BaseTest
+{
+
+    public function testDefaultConfig()
+    {
+        $db = 'zoop-shard';
+        $manifest = new Manifest(
+            [
+                'extension_configs' => [
+                    'extension.serializer' => true,
+                    'extension.odmcore' => true
+                ]
+            ]
+        );
+        /* @var $core CoreExtension */
+        $core = $manifest->getServiceManager()->get('extension.odmcore');
+
+        $this->assertEquals($db, $core->getDefaultDb());
+    }
+
+    public function testMergedConfig()
+    {
+        $db = 'zoop-shard-test';
+        $manifest = new Manifest(
+            [
+                'extension_configs' => [
+                    'extension.serializer' => true,
+                    'extension.odmcore' => [
+                        'default_db' => $db
+                    ]
+                ]
+            ]
+        );
+        /* @var $core CoreExtension */
+        $core = $manifest->getServiceManager()->get('extension.odmcore');
+
+        $this->assertEquals($db, $core->getDefaultDb());
+    }
+}


### PR DESCRIPTION
Extension configs previously did not seem to merge correctly. For example there didn't seem to be a way to override `default_db` without creating a whole new `DocumentManagerFactory` which seems a little to verbose.

I thought something like this would work?

``` php
$manifest = new Manifest(
            [
                'extension_configs' => [
                    'extension.serializer' => true,
                    'extension.odmcore' => [
                        'default_db' => 'test_db'
                    ]
                ]
            ]
        );
```

Let me know if it's completely wrong.
