### PR TITLE
Hotfix/Unserializer with passed document

### DIFF
--- a/tests/Zoop/Shard/Test/Serializer/UnserializeModeTest.php
+++ b/tests/Zoop/Shard/Test/Serializer/UnserializeModeTest.php
@@ -11,6 +11,7 @@ use Zoop\Shard\Test\Serializer\TestAsset\Document\Profile;
 
 class UnserializeModeTest extends BaseTest
 {
+    const USER_CLASS = 'Zoop\Shard\Test\Serializer\TestAsset\Document\User';
     public function setUp()
     {
         $manifest = new Manifest(
@@ -56,7 +57,8 @@ class UnserializeModeTest extends BaseTest
                 ],
                 'active' => false
             ],
-            'Zoop\Shard\Test\Serializer\TestAsset\Document\User'
+            self::USER_CLASS,
+            $user
         );
 
         $this->assertEquals('there', $updated->location());
@@ -94,14 +96,18 @@ class UnserializeModeTest extends BaseTest
                 'id' => $id,
                 'groups' => $groups
             ],
-            'Zoop\Shard\Test\Serializer\TestAsset\Document\User'
+            self::USER_CLASS,
+            $user
         );
 
         $this->assertCount(3, $updated->getGroups());
 
-        $documentManager->remove($updated);
+        $documentManager->persist($updated);
         $documentManager->flush();
         $documentManager->clear();
+
+        $userFind = $documentManager->find(self::USER_CLASS, $id);
+        $this->assertCount(3, $userFind->getGroups());
     }
 
     public function testUnserializePatchRemoveItemFromCollection()
@@ -127,14 +133,18 @@ class UnserializeModeTest extends BaseTest
                 'id' => $id,
                 'groups' => $groups
             ],
-            'Zoop\Shard\Test\Serializer\TestAsset\Document\User'
+            self::USER_CLASS,
+            $user
         );
 
         $this->assertCount(1, $updated->getGroups());
 
-        $documentManager->remove($updated);
+        $documentManager->persist($updated);
         $documentManager->flush();
         $documentManager->clear();
+
+        $userFind = $documentManager->find(self::USER_CLASS, $id);
+        $this->assertCount(1, $userFind->getGroups());
     }
 
     public function testUnserializePatchEmptyCollection()
@@ -157,14 +167,17 @@ class UnserializeModeTest extends BaseTest
                 'id' => $id,
                 'groups' => []
             ],
-            'Zoop\Shard\Test\Serializer\TestAsset\Document\User'
+            self::USER_CLASS,
+            $user
         );
-
         $this->assertCount(0, $updated->getGroups());
 
-        $documentManager->remove($updated);
+        $documentManager->persist($updated);
         $documentManager->flush();
         $documentManager->clear();
+
+        $userFind = $documentManager->find(self::USER_CLASS, $id);
+        $this->assertCount(0, $userFind->getGroups());
     }
 
     public function testUnserializeUpdateGeneral()
@@ -193,8 +206,8 @@ class UnserializeModeTest extends BaseTest
                     'firstname' => 'Tom'
                 ]
             ],
-            'Zoop\Shard\Test\Serializer\TestAsset\Document\User',
-            null,
+            self::USER_CLASS,
+            $user,
             Unserializer::UNSERIALIZE_UPDATE
         );
 
@@ -233,16 +246,19 @@ class UnserializeModeTest extends BaseTest
                 'id' => $id,
                 'groups' => $groups
             ],
-            'Zoop\Shard\Test\Serializer\TestAsset\Document\User',
-            null,
+            self::USER_CLASS,
+            $user,
             Unserializer::UNSERIALIZE_UPDATE
         );
 
         $this->assertCount(3, $updated->getGroups());
 
-        $documentManager->remove($updated);
+        $documentManager->persist($updated);
         $documentManager->flush();
         $documentManager->clear();
+
+        $userFind = $documentManager->find(self::USER_CLASS, $id);
+        $this->assertCount(3, $userFind->getGroups());
     }
 
     public function testUnserializeUpdateRemoveItemFromCollection()
@@ -267,16 +283,19 @@ class UnserializeModeTest extends BaseTest
                 'id' => $id,
                 'groups' => $groups
             ],
-            'Zoop\Shard\Test\Serializer\TestAsset\Document\User',
-            null,
+            self::USER_CLASS,
+            $user,
             Unserializer::UNSERIALIZE_UPDATE
         );
 
         $this->assertCount(1, $updated->getGroups());
 
-        $documentManager->remove($updated);
+        $documentManager->persist($updated);
         $documentManager->flush();
         $documentManager->clear();
+
+        $userFind = $documentManager->find(self::USER_CLASS, $id);
+        $this->assertCount(1, $userFind->getGroups());
     }
 
     public function testUnserializeUpdateEmptyCollection()
@@ -298,15 +317,18 @@ class UnserializeModeTest extends BaseTest
                 'id' => $id,
                 'groups' => []
             ],
-            'Zoop\Shard\Test\Serializer\TestAsset\Document\User',
-            null,
+            self::USER_CLASS,
+            $user,
             Unserializer::UNSERIALIZE_UPDATE
         );
 
         $this->assertCount(0, $updated->getGroups());
 
-        $documentManager->remove($updated);
+        $documentManager->persist($updated);
         $documentManager->flush();
         $documentManager->clear();
+
+        $userFind = $documentManager->find(self::USER_CLASS, $id);
+        $this->assertCount(0, $userFind->getGroups());
     }
 }


### PR DESCRIPTION
When updating or patching a document using the unserializer, and also passing in the original document, collections would not persist correctly. eg.

```
{
  "_id" : "6088b3b8158734499517cbca32f09743",
  "groups" : [{
      "name" : "groupA"
    }, {
      "name" : "groupB"
    }]
}
```

Then calling:

``` php
...
 $updated = $this->unserializer->fromArray(
            [
                'id' => $id,
                'groups' => []
            ],
            'Zoop\Shard\Test\Serializer\TestAsset\Document\User',
            $user
        );
...
```

Would still appear like the following **in the DB**:

```
{
  "_id" : "6088b3b8158734499517cbca32f09743",
  "groups" : [{
      "name" : "groupA"
    }, {
      "name" : "groupB"
    }]
}
```

However, it would appear correctly in `$updated`, and therefore giving a false positive in the tests.

I have updated the `UnserializeModeTest` to ensure all tests have a document explicitly passed in to ensure this problem is avoided. **Should we also have tests that don't pass `$user` in**?

Also, I'm not sure if my treatment was ok for this: https://github.com/crimsonronin/shard/blob/Hotfix/UnserializerWithPassedDocument/lib/Zoop/Shard/Serializer/Unserializer.php#L288
