### PR TITLE
Several updates for shard - no BC breaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ before_script:
 script:
   - cd ./tests
   - ../vendor/bin/phpunit --coverage-clover ../build/clover.xml
-  - php ../build/coverage-checker.php ../build/clover.xml 84
+  - php ../build/coverage-checker.php ../build/clover.xml 85
   - ../vendor/bin/phpmd --exclude ClassMetadataTrait.php ../lib/ text ruleset.xml
   - ../vendor/bin/phpcs --standard=PSR2 ../lib/ ./Zoop/

--- a/lib/Zoop/Shard/AbstractExtension.php
+++ b/lib/Zoop/Shard/AbstractExtension.php
@@ -16,12 +16,6 @@ use Zend\Stdlib\AbstractOptions;
  */
 abstract class AbstractExtension extends AbstractOptions
 {
-    protected $models = [];
-
-    protected $subscribers = [];
-
-    protected $serviceManagerConfig = [];
-
     /**
      * List of other extensions which must be loaded
      * for this extension to work
@@ -30,35 +24,18 @@ abstract class AbstractExtension extends AbstractOptions
      */
     protected $dependencies = [];
 
-    public function getServiceManagerConfig()
-    {
-        return $this->serviceManagerConfig;
-    }
+    /**
+     * List of events that are triggered instead of raising an exception
+     *
+     * @var array
+     */
+    protected $exceptionEvents = [];
 
-    public function setServiceManagerConfig($serviceManagerConfig)
-    {
-        $this->serviceManagerConfig = $serviceManagerConfig;
-    }
+    protected $models = [];
 
-    public function getModels()
-    {
-        return $this->models;
-    }
+    protected $subscribers = [];
 
-    public function setModels($models)
-    {
-        $this->models = $models;
-    }
-
-    public function getSubscribers()
-    {
-        return $this->subscribers;
-    }
-
-    public function setSubscribers($subscribers)
-    {
-        $this->subscribers = $subscribers;
-    }
+    protected $serviceManagerConfig = [];
 
     /**
      *
@@ -76,5 +53,45 @@ abstract class AbstractExtension extends AbstractOptions
     public function setDependencies(array $dependencies)
     {
         $this->dependencies = $dependencies;
+    }
+
+    public function getExceptionEvents()
+    {
+        return $this->exceptionEvents;
+    }
+
+    public function setExceptionEvents($exceptionEvents)
+    {
+        $this->exceptionEvents = $exceptionEvents;
+    }
+
+    public function getModels()
+    {
+        return $this->models;
+    }
+
+    public function setModels($models)
+    {
+        $this->models = $models;
+    }
+
+    public function getServiceManagerConfig()
+    {
+        return $this->serviceManagerConfig;
+    }
+
+    public function setServiceManagerConfig($serviceManagerConfig)
+    {
+        $this->serviceManagerConfig = $serviceManagerConfig;
+    }
+
+    public function getSubscribers()
+    {
+        return $this->subscribers;
+    }
+
+    public function setSubscribers($subscribers)
+    {
+        $this->subscribers = $subscribers;
     }
 }

--- a/lib/Zoop/Shard/AccessControl/Extension.php
+++ b/lib/Zoop/Shard/AccessControl/Extension.php
@@ -39,6 +39,12 @@ class Extension extends AbstractExtension
         ]
     ];
 
+    protected $exceptionEvents = [
+        Events::CREATE_DENIED,
+        Events::DELETE_DENIED,
+        Events::UPDATE_DENIED,
+    ];
+
     /**
      *
      * @var array

--- a/lib/Zoop/Shard/Core/EventManagerFactory.php
+++ b/lib/Zoop/Shard/Core/EventManagerFactory.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @package    Zoop
+ * @license    MIT
+ */
+namespace Zoop\Shard\Core;
+
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ *
+ * @since   1.0
+ * @version $Revision$
+ * @author  Tim Roediger <superdweebie@gmail.com>
+ */
+class EventManagerFactory implements FactoryInterface
+{
+    /**
+     *
+     * @param  \Zend\ServiceManager\ServiceLocatorInterface $serviceLocator
+     * @return object
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return new EventManager;
+    }
+}

--- a/lib/Zoop/Shard/Core/EventManagerFactory.php
+++ b/lib/Zoop/Shard/Core/EventManagerFactory.php
@@ -17,7 +17,8 @@ use Zend\ServiceManager\ServiceLocatorInterface;
 class EventManagerFactory implements FactoryInterface
 {
     /**
-     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * 
      * @param  \Zend\ServiceManager\ServiceLocatorInterface $serviceLocator
      * @return object
      */

--- a/lib/Zoop/Shard/Core/Events.php
+++ b/lib/Zoop/Shard/Core/Events.php
@@ -46,4 +46,6 @@ final class Events
     const LOAD_METADATA = 'loadMetadata';
 
     const BOOTSTRAPPED = 'bootstrapped';
+
+    const EXCEPTION = 'exception';
 }

--- a/lib/Zoop/Shard/Core/ExceptionEventArgs.php
+++ b/lib/Zoop/Shard/Core/ExceptionEventArgs.php
@@ -15,15 +15,23 @@ use Doctrine\Common\EventArgs as BaseEventArgs;
  */
 class ExceptionEventArgs extends BaseEventArgs
 {
+    protected $name;
+
     protected $innerEvent;
+
+    public function getName()
+    {
+        return $this->name;
+    }
 
     public function getInnerEvent()
     {
         return $this->innerEvent;
     }
 
-    public function __construct(BaseEventArgs $innerEvent)
+    public function __construct($name, BaseEventArgs $innerEvent)
     {
+        $this->name = (string) $name;
         $this->innerEvent = $innerEvent;
     }
 }

--- a/lib/Zoop/Shard/Core/ExceptionEventArgs.php
+++ b/lib/Zoop/Shard/Core/ExceptionEventArgs.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @link       http://zoopcommerce.github.io/shard
+ * @package    Zoop
+ * @license    MIT
+ */
+namespace Zoop\Shard\Core;
+
+use Doctrine\Common\EventArgs as BaseEventArgs;
+
+/**
+ *
+ * @since   1.0
+ * @author  Tim Roediger <superdweebie@gmail.com>
+ */
+class ExceptionEventArgs extends BaseEventArgs
+{
+    protected $innerEvent;
+
+    public function getInnerEvent()
+    {
+        return $this->innerEvent;
+    }
+
+    public function __construct(BaseEventArgs $innerEvent)
+    {
+        $this->innerEvent = $innerEvent;
+    }
+}

--- a/lib/Zoop/Shard/Crypt/BlockCipherHelper.php
+++ b/lib/Zoop/Shard/Crypt/BlockCipherHelper.php
@@ -24,14 +24,9 @@ class BlockCipherHelper implements ServiceLocatorAwareInterface
         $cryptMetadata = $metadata->getCrypt();
         if (isset($cryptMetadata['blockCipher'])) {
             foreach ($cryptMetadata['blockCipher'] as $field => $config) {
-                $service = $this->serviceLocator->get($config['service']);
-                if (! $service instanceof BlockCipherServiceInterface) {
-                    throw new \Zoop\Shard\Exception\InvalidArgumentException();
-                }
-                $service->encryptField($field, $document, $metadata);
+                $this->getBlockCipherService($config)->encryptField($field, $document, $metadata);
             }
         }
-
     }
 
     public function decryptDocument($document, $metadata)
@@ -39,12 +34,33 @@ class BlockCipherHelper implements ServiceLocatorAwareInterface
         $cryptMetadata = $metadata->getCrypt();
         if (isset($cryptMetadata['blockCipher'])) {
             foreach ($cryptMetadata['blockCipher'] as $field => $config) {
-                $service = $this->serviceLocator->get($config['service']);
-                if (! $service instanceof BlockCipherServiceInterface) {
-                    throw new \Zoop\Shard\Exception\InvalidArgumentException();
-                }
-                $service->decryptField($field, $document, $metadata);
+                $this->getBlockCipherService($config)->decryptField($field, $document, $metadata);
             }
         }
+    }
+
+    public function encryptField($field, $document, $metadata)
+    {
+        $cryptMetadata = $metadata->getCrypt();
+        if (isset($cryptMetadata['blockCipher']) && isset($cryptMetadata['blockCipher'][$field])) {
+            $this->getBlockCipherService($cryptMetadata['blockCipher'][$field])->encryptField($field, $document, $metadata);
+        }
+    }
+
+    public function decryptField($field, $document, $metadata)
+    {
+        $cryptMetadata = $metadata->getCrypt();
+        if (isset($cryptMetadata['blockCipher']) && isset($cryptMetadata['blockCipher'][$field])) {
+            $this->getBlockCipherService($cryptMetadata['blockCipher'][$field])->decryptField($field, $document, $metadata);
+        }
+    }
+
+    protected function getBlockCipherService($config)
+    {
+        $service = $this->serviceLocator->get($config['service']);
+        if (! $service instanceof BlockCipherServiceInterface) {
+            throw new \Zoop\Shard\Exception\InvalidArgumentException();
+        }
+        return $service;
     }
 }

--- a/lib/Zoop/Shard/Crypt/BlockCipherHelper.php
+++ b/lib/Zoop/Shard/Crypt/BlockCipherHelper.php
@@ -43,7 +43,8 @@ class BlockCipherHelper implements ServiceLocatorAwareInterface
     {
         $cryptMetadata = $metadata->getCrypt();
         if (isset($cryptMetadata['blockCipher']) && isset($cryptMetadata['blockCipher'][$field])) {
-            $this->getBlockCipherService($cryptMetadata['blockCipher'][$field])->encryptField($field, $document, $metadata);
+            $this->getBlockCipherService($cryptMetadata['blockCipher'][$field])
+                ->encryptField($field, $document, $metadata);
         }
     }
 
@@ -51,7 +52,8 @@ class BlockCipherHelper implements ServiceLocatorAwareInterface
     {
         $cryptMetadata = $metadata->getCrypt();
         if (isset($cryptMetadata['blockCipher']) && isset($cryptMetadata['blockCipher'][$field])) {
-            $this->getBlockCipherService($cryptMetadata['blockCipher'][$field])->decryptField($field, $document, $metadata);
+            $this->getBlockCipherService($cryptMetadata['blockCipher'][$field])
+                ->decryptField($field, $document, $metadata);
         }
     }
 

--- a/lib/Zoop/Shard/Crypt/HashHelper.php
+++ b/lib/Zoop/Shard/Crypt/HashHelper.php
@@ -24,12 +24,25 @@ class HashHelper implements ServiceLocatorAwareInterface
         $cryptMetadata = $metadata->getCrypt();
         if (isset($cryptMetadata['hash'])) {
             foreach ($cryptMetadata['hash'] as $field => $config) {
-                $service = $this->serviceLocator->get($config['service']);
-                if (! $service instanceof HashServiceInterface) {
-                    throw new \Zoop\Shard\Exception\InvalidArgumentException();
-                }
-                $service->hashField($field, $document, $metadata);
+                $this->getHashService($config)->hashField($field, $document, $metadata);
             }
         }
+    }
+
+    public function hashField($field, $document, $metadata)
+    {
+        $cryptMetadata = $metadata->getCrypt();
+        if (isset($cryptMetadata['hash']) && isset($cryptMetadata['hash'][$field])) {
+            $this->getHashService($cryptMetadata['hash'][$field])->hashField($field, $document, $metadata);
+        }
+    }
+    
+    protected function getHashService($config)
+    {
+        $service = $this->serviceLocator->get($config['service']);
+        if (! $service instanceof HashServiceInterface) {
+            throw new \Zoop\Shard\Exception\InvalidArgumentException();
+        }
+        return $service;
     }
 }

--- a/lib/Zoop/Shard/Freeze/AccessControl/FreezeSubscriber.php
+++ b/lib/Zoop/Shard/Freeze/AccessControl/FreezeSubscriber.php
@@ -52,12 +52,12 @@ class FreezeSubscriber extends AbstractAccessControlSubscriber
             //stop freeze
             $this->getFreezer()->thaw($document, $metadata);
 
-            $eventArgs->setReject(true);
-
             $eventArgs->getEventManager()->dispatchEvent(
                 Events::FREEZE_DENIED,
                 new AccessControlEventArgs($document, Actions::FREEZE)
             );
+
+            $eventArgs->setReject(true);
         }
     }
 
@@ -81,12 +81,12 @@ class FreezeSubscriber extends AbstractAccessControlSubscriber
             //stop thaw
             $this->getFreezer()->freeze($document, $metadata);
 
-            $eventArgs->setReject(true);
-
             $eventArgs->getEventManager()->dispatchEvent(
                 Events::THAW_DENIED,
                 new AccessControlEventArgs($document, Actions::THAW)
             );
+
+            $eventArgs->setReject(true);
         }
     }
 

--- a/lib/Zoop/Shard/Freeze/Extension.php
+++ b/lib/Zoop/Shard/Freeze/Extension.php
@@ -39,6 +39,13 @@ class Extension extends AbstractExtension
         ]
     ];
 
+    protected $exceptionEvents = [
+        Events::FREEZE_DENIED,
+        Events::THAW_DENIED,
+        Events::FROZEN_DELETE_DENIED,
+        Events::FROZEN_UPDATE_DENIED,
+    ];
+
     protected $dependencies = [
         'extension.annotation' => true
     ];

--- a/lib/Zoop/Shard/Manifest.php
+++ b/lib/Zoop/Shard/Manifest.php
@@ -26,8 +26,7 @@ class Manifest extends AbstractExtension
 {
     protected $defaultServiceManagerConfig = [
         'invokables' => [
-            'modelmanager.delegator.factory' => 'Zoop\Shard\Core\ModelManagerDelegatorFactory',
-            'eventmanager'                    => 'Zoop\Shard\Core\EventManager'
+            'modelmanager.delegator.factory' => 'Zoop\Shard\Core\ModelManagerDelegatorFactory'
         ],
         'factories' => [
             'extension.accesscontrol'   => 'Zoop\Shard\AccessControl\ExtensionFactory',
@@ -47,6 +46,7 @@ class Manifest extends AbstractExtension
             'extension.validator'       => 'Zoop\Shard\Validator\ExtensionFactory',
             'extension.zone'            => 'Zoop\Shard\Zone\ExtensionFactory',
             'subscriber.lazysubscriber' => 'Zoop\Shard\Core\LazySubscriberFactory',
+            'eventmanager'              => 'Zoop\Shard\Core\EventManagerFactory'
         ],
         'delegators' => [
             'modelmanager' => ['modelmanager.delegator.factory']

--- a/lib/Zoop/Shard/ODMCore/ExceptionEventsAggregator.php
+++ b/lib/Zoop/Shard/ODMCore/ExceptionEventsAggregator.php
@@ -6,10 +6,12 @@
 namespace Zoop\Shard\ODMCore;
 
 use Doctrine\Common\EventArgs;
-use Doctrine\Common\EventManager;
 use Doctrine\Common\EventSubscriber;
+use Zend\ServiceManager\ServiceLocatorAwareInterface;
+use Zend\ServiceManager\ServiceLocatorAwareTrait;
 use Zoop\Shard\Core\Events;
 use Zoop\Shard\Core\ExceptionEventArgs;
+use Zoop\Shard\Core\EventManagerTrait;
 
 /**
  *
@@ -17,11 +19,12 @@ use Zoop\Shard\Core\ExceptionEventArgs;
  * @version $Revision$
  * @author  Tim Roediger <superdweebie@gmail.com>
  */
-class ExceptionEventsAggregator implements EventSubscriber
+class ExceptionEventsAggregator implements EventSubscriber, ServiceLocatorAwareInterface
 {
-    protected $exceptionEvents;
+    use ServiceLocatorAwareTrait;
+    use EventManagerTrait;
 
-    protected $eventManager;
+    protected $exceptionEvents;
 
     public function getSubscribedEvents()
     {
@@ -38,20 +41,12 @@ class ExceptionEventsAggregator implements EventSubscriber
         $this->exceptionEvents = $exceptionEvents;
     }
 
-    public function __construct(EventManager $eventManager)
-    {
-        $this->eventManager = $eventManager;
-    }
-
-    /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     */
     public function __call($name, $args)
     {
         if (!($args[0] instanceof EventArgs)) {
             return;
         }
 
-        $this->eventManager->dispatchEvent(Events::EXCEPTION, new ExceptionEventArgs($args[0]));
+        $this->getEventManager()->dispatchEvent(Events::EXCEPTION, new ExceptionEventArgs($name, $args[0]));
     }
 }

--- a/lib/Zoop/Shard/ODMCore/ExceptionEventsAggregator.php
+++ b/lib/Zoop/Shard/ODMCore/ExceptionEventsAggregator.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * @package    Zoop
+ * @license    MIT
+ */
+namespace Zoop\Shard\ODMCore;
+
+use Doctrine\Common\EventArgs;
+use Doctrine\Common\EventManager;
+use Doctrine\Common\EventSubscriber;
+use Zoop\Shard\Core\Events;
+use Zoop\Shard\Core\ExceptionEventArgs;
+
+/**
+ *
+ * @since   1.0
+ * @version $Revision$
+ * @author  Tim Roediger <superdweebie@gmail.com>
+ */
+class ExceptionEventsAggregator implements EventSubscriber
+{
+    protected $exceptionEvents;
+
+    protected $eventManager;
+
+    public function getSubscribedEvents()
+    {
+        return $this->exceptionEvents;
+    }
+
+    public function getExceptionEvents()
+    {
+        return $this->exceptionEvents;
+    }
+
+    public function setExceptionEvents(array $exceptionEvents)
+    {
+        $this->exceptionEvents = $exceptionEvents;
+    }
+
+    public function __construct(EventManager $eventManager)
+    {
+        $this->eventManager = $eventManager;
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function __call($name, $args)
+    {
+        if (!($args[0] instanceof EventArgs)) {
+            return;
+        }
+
+        $this->eventManager->dispatchEvent(Events::EXCEPTION, new ExceptionEventArgs($args[0]));
+    }
+}

--- a/lib/Zoop/Shard/ODMCore/ExceptionEventsAggregatorFactory.php
+++ b/lib/Zoop/Shard/ODMCore/ExceptionEventsAggregatorFactory.php
@@ -28,7 +28,7 @@ class ExceptionEventsAggregatorFactory implements FactoryInterface
         $subscriber = new ExceptionEventsAggregator();
 
         $exceptionEvents = [];
-        foreach ($manifest->getExtensionConfigs() as $extensionConfig){
+        foreach ($manifest->getExtensionConfigs() as $extensionConfig) {
             $exceptionEvents = array_merge($exceptionEvents, $extensionConfig['exception_events']);
         }
         $subscriber->setExceptionEvents($exceptionEvents);

--- a/lib/Zoop/Shard/ODMCore/ExceptionEventsAggregatorFactory.php
+++ b/lib/Zoop/Shard/ODMCore/ExceptionEventsAggregatorFactory.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @package    Zoop
+ * @license    MIT
+ */
+namespace Zoop\Shard\ODMCore;
+
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ *
+ * @since   1.0
+ * @version $Revision$
+ * @author  Tim Roediger <superdweebie@gmail.com>
+ */
+class ExceptionEventsAggregatorFactory implements FactoryInterface
+{
+    /**
+     *
+     * @param  \Zend\ServiceManager\ServiceLocatorInterface $serviceLocator
+     * @return object
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        $manifest = $serviceLocator->get('manifest');
+
+        $subscriber = new ExceptionEventsAggregator($serviceLocator->get('eventmanager'));
+
+        $exceptionEvents = [];
+        foreach ($manifest->getExtensionConfigs() as $extensionConfig){
+            $exceptionEvents = array_merge($exceptionEvents, $extensionConfig['exception_events']);
+        }
+        $subscriber->setExceptionEvents($exceptionEvents);
+
+        return $subscriber;
+    }
+}

--- a/lib/Zoop/Shard/ODMCore/ExceptionEventsAggregatorFactory.php
+++ b/lib/Zoop/Shard/ODMCore/ExceptionEventsAggregatorFactory.php
@@ -25,7 +25,7 @@ class ExceptionEventsAggregatorFactory implements FactoryInterface
     {
         $manifest = $serviceLocator->get('manifest');
 
-        $subscriber = new ExceptionEventsAggregator($serviceLocator->get('eventmanager'));
+        $subscriber = new ExceptionEventsAggregator();
 
         $exceptionEvents = [];
         foreach ($manifest->getExtensionConfigs() as $extensionConfig){

--- a/lib/Zoop/Shard/ODMCore/Extension.php
+++ b/lib/Zoop/Shard/ODMCore/Extension.php
@@ -19,6 +19,7 @@ class Extension extends AbstractExtension
 
     protected $subscribers = [
         'subscriber.odmcore.boostrappedsubscriber',
+        'subscriber.odmcore.exceptioneventsaggregator',
         'subscriber.odmcore.flushsubscriber',
         'subscriber.odmcore.preloadsubscriber',
         'subscriber.odmcore.loadmetadatasubscriber'
@@ -36,7 +37,8 @@ class Extension extends AbstractExtension
                 'Zoop\Shard\ODMCore\LoadMetadataSubscriber'
         ],
         'factories' => [
-            'modelmanager' => 'Zoop\Shard\ODMCore\DevDocumentManagerFactory'
+            'modelmanager'                                 => 'Zoop\Shard\ODMCore\DevDocumentManagerFactory',
+            'subscriber.odmcore.exceptioneventsaggregator' => 'Zoop\Shard\ODMCore\ExceptionEventsAggregatorFactory'
         ]
     ];
 

--- a/lib/Zoop/Shard/SoftDelete/AccessControl/SoftDeleteSubscriber.php
+++ b/lib/Zoop/Shard/SoftDelete/AccessControl/SoftDeleteSubscriber.php
@@ -51,12 +51,12 @@ class SoftDeleteSubscriber extends AbstractAccessControlSubscriber
             //stop SoftDelete
             $this->getSoftDeleter()->restore($document, $metadata);
 
-            $eventArgs->setReject(true);
-
             $eventArgs->getEventManager()->dispatchEvent(
                 Events::SOFT_DELETE_DENIED,
                 $eventArgs
             );
+
+            $eventArgs->setReject(true);
         }
     }
 
@@ -79,12 +79,12 @@ class SoftDeleteSubscriber extends AbstractAccessControlSubscriber
             //stop restore
             $this->getSoftDeleter()->softDelete($document, $metadata);
 
-            $eventArgs->setReject(true);
-
             $eventArgs->getEventManager()->dispatchEvent(
                 Events::RESTORE_DENIED,
                 $eventArgs
             );
+
+            $eventArgs->setReject(true);
         }
     }
 

--- a/lib/Zoop/Shard/SoftDelete/Extension.php
+++ b/lib/Zoop/Shard/SoftDelete/Extension.php
@@ -40,6 +40,12 @@ class Extension extends AbstractExtension
         ]
     ];
 
+    protected $exceptionEvents = [
+        Events::RESTORE_DENIED,
+        Events::SOFT_DELETE_DENIED,
+        Events::SOFT_DELETED_UPDATE_DENIED,
+    ];
+
     protected $dependencies = [
         'extension.annotation' => true
     ];

--- a/lib/Zoop/Shard/State/Extension.php
+++ b/lib/Zoop/Shard/State/Extension.php
@@ -36,6 +36,11 @@ class Extension extends AbstractExtension
         ]
     ];
 
+    protected $exceptionEvents = [
+        Events::TRANSITION_DENIED,
+        Events::BAD_STATE,
+    ];
+
     protected $dependencies = [
         'extension.annotation' => true
     ];

--- a/lib/Zoop/Shard/State/MainSubscriber.php
+++ b/lib/Zoop/Shard/State/MainSubscriber.php
@@ -88,9 +88,8 @@ class MainSubscriber implements EventSubscriber, ServiceLocatorAwareInterface
         //stop state change if the new state is not on the defined state list
         if (count($stateMetadata[$field]) > 0 && ! in_array($toState, $stateMetadata[$field])) {
             $metadata->setFieldValue($document, $field, $fromState);
-            $eventArgs->setReject(true);
             $eventManager->dispatchEvent(Events::BAD_STATE, $eventArgs);
-
+            $eventArgs->setReject(true);
             return;
         }
 
@@ -136,11 +135,8 @@ class MainSubscriber implements EventSubscriber, ServiceLocatorAwareInterface
         if (count($stateMetadata[$field]) > 0 &&
             ! in_array($metadata->getFieldValue($document, $field), $stateMetadata[$field])
         ) {
+            $eventArgs->getEventManager()->dispatchEvent(Events::BAD_STATE, $eventArgs);
             $eventArgs->setReject(true);
-            $eventArgs->getEventManager()->dispatchEvent(
-                Events::BAD_STATE,
-                $eventArgs
-            );
         }
     }
 }

--- a/lib/Zoop/Shard/Validator/Extension.php
+++ b/lib/Zoop/Shard/Validator/Extension.php
@@ -22,6 +22,10 @@ class Extension extends AbstractExtension
         'subscriber.validator.annotationsubscriber'
     ];
 
+    protected $exceptionEvents = [
+        Events::INVALID_MODEL,
+    ];
+
     protected $dependencies = [
         'extension.annotation' => true,
     ];

--- a/tests/Zoop/Shard/Test/Crypt/BlockCipherHelperTest.php
+++ b/tests/Zoop/Shard/Test/Crypt/BlockCipherHelperTest.php
@@ -37,12 +37,18 @@ class BlockCipherHelperTest extends BaseTest
         $testDoc->setFirstname('Tommy');
         $testDoc->setLastname('Hatchling');
 
-        $this->blockCipherHelper->encryptDocument($testDoc, $this->documentManager->getClassMetadata(get_class($testDoc)));
+        $this->blockCipherHelper->encryptDocument(
+            $testDoc,
+            $this->documentManager->getClassMetadata(get_class($testDoc))
+        );
 
         $this->assertNotEquals('Tommy', $testDoc->getFirstname());
         $this->assertNotEquals('Hatchling', $testDoc->getLastname());
 
-        $this->blockCipherHelper->decryptDocument($testDoc, $this->documentManager->getClassMetadata(get_class($testDoc)));
+        $this->blockCipherHelper->decryptDocument(
+            $testDoc,
+            $this->documentManager->getClassMetadata(get_class($testDoc))
+        );
 
         $this->assertEquals('Tommy', $testDoc->getFirstname());
         $this->assertEquals('Hatchling', $testDoc->getLastname());
@@ -54,12 +60,20 @@ class BlockCipherHelperTest extends BaseTest
         $testDoc->setFirstname('Tommy');
         $testDoc->setLastname('Hatchling');
 
-        $this->blockCipherHelper->encryptField('firstname', $testDoc, $this->documentManager->getClassMetadata(get_class($testDoc)));
+        $this->blockCipherHelper->encryptField(
+            'firstname',
+            $testDoc,
+            $this->documentManager->getClassMetadata(get_class($testDoc))
+        );
 
         $this->assertNotEquals('Tommy', $testDoc->getFirstname());
         $this->assertEquals('Hatchling', $testDoc->getLastname());
 
-        $this->blockCipherHelper->decryptField('firstname', $testDoc, $this->documentManager->getClassMetadata(get_class($testDoc)));
+        $this->blockCipherHelper->decryptField(
+            'firstname',
+            $testDoc,
+            $this->documentManager->getClassMetadata(get_class($testDoc))
+        );
 
         $this->assertEquals('Tommy', $testDoc->getFirstname());
         $this->assertEquals('Hatchling', $testDoc->getLastname());

--- a/tests/Zoop/Shard/Test/Crypt/BlockCipherHelperTest.php
+++ b/tests/Zoop/Shard/Test/Crypt/BlockCipherHelperTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Zoop\Shard\Test\Crypt;
+
+use Zoop\Shard\Manifest;
+use Zoop\Shard\Test\BaseTest;
+use Zoop\Shard\Test\Crypt\TestAsset\Document\MultipleBlockCipher;
+
+class BlockCipherHelperTest extends BaseTest
+{
+    public function setUp()
+    {
+        $manifest = new Manifest(
+            [
+                'models' => [
+                    __NAMESPACE__ . '\TestAsset\Document' => __DIR__ . '/TestAsset/Document'
+                ],
+                'extension_configs' => [
+                    'extension.crypt' => true,
+                    'extension.odmcore' => true
+                ],
+                'service_manager_config' => [
+                    'invokables' => [
+                        'testkey' => 'Zoop\Shard\Test\Crypt\TestAsset\Key'
+                    ],
+                ]
+           ]
+        );
+
+        $this->documentManager = $manifest->getServiceManager()->get('modelmanager');
+        $this->blockCipherHelper = $manifest->getServiceManager()->get('crypt.blockcipherhelper');
+    }
+
+    public function testEncryptDecryptAllFields()
+    {
+        $testDoc = new MultipleBlockCipher();
+        $testDoc->setFirstname('Tommy');
+        $testDoc->setLastname('Hatchling');
+
+        $this->blockCipherHelper->encryptDocument($testDoc, $this->documentManager->getClassMetadata(get_class($testDoc)));
+
+        $this->assertNotEquals('Tommy', $testDoc->getFirstname());
+        $this->assertNotEquals('Hatchling', $testDoc->getLastname());
+
+        $this->blockCipherHelper->decryptDocument($testDoc, $this->documentManager->getClassMetadata(get_class($testDoc)));
+
+        $this->assertEquals('Tommy', $testDoc->getFirstname());
+        $this->assertEquals('Hatchling', $testDoc->getLastname());
+    }
+
+    public function testEncryptDecryptSingleField()
+    {
+        $testDoc = new MultipleBlockCipher();
+        $testDoc->setFirstname('Tommy');
+        $testDoc->setLastname('Hatchling');
+
+        $this->blockCipherHelper->encryptField('firstname', $testDoc, $this->documentManager->getClassMetadata(get_class($testDoc)));
+
+        $this->assertNotEquals('Tommy', $testDoc->getFirstname());
+        $this->assertEquals('Hatchling', $testDoc->getLastname());
+
+        $this->blockCipherHelper->decryptField('firstname', $testDoc, $this->documentManager->getClassMetadata(get_class($testDoc)));
+
+        $this->assertEquals('Tommy', $testDoc->getFirstname());
+        $this->assertEquals('Hatchling', $testDoc->getLastname());
+    }
+}

--- a/tests/Zoop/Shard/Test/Crypt/HashHelperTest.php
+++ b/tests/Zoop/Shard/Test/Crypt/HashHelperTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Zoop\Shard\Test\Crypt;
+
+use Zoop\Shard\Manifest;
+use Zoop\Shard\Test\BaseTest;
+use Zoop\Shard\Test\Crypt\TestAsset\Document\MultipleHash;
+
+class HashHelperTest extends BaseTest
+{
+    public function setUp()
+    {
+        $manifest = new Manifest(
+            [
+                'models' => [
+                    __NAMESPACE__ . '\TestAsset\Document' => __DIR__ . '/TestAsset/Document'
+                ],
+                'extension_configs' => [
+                    'extension.crypt' => true,
+                    'extension.odmcore' => true
+                ],
+                'service_manager_config' => [
+                    'invokables' => [
+                        'testsalt' => 'Zoop\Shard\Test\Crypt\TestAsset\Salt'
+                    ],
+                ]
+           ]
+        );
+
+        $this->documentManager = $manifest->getServiceManager()->get('modelmanager');
+        $this->hashHelper = $manifest->getServiceManager()->get('crypt.hashhelper');
+    }
+
+    public function testHashAllFields()
+    {
+        $testDoc = new MultipleHash();
+        $testDoc->setFirstname('Tommy');
+        $testDoc->setLastname('Hatchling');
+
+        $this->hashHelper->hashDocument($testDoc, $this->documentManager->getClassMetadata(get_class($testDoc)));
+
+        $this->assertNotEquals('Tommy', $testDoc->getFirstname());
+        $this->assertNotEquals('Hatchling', $testDoc->getLastname());
+    }
+
+    public function testHashSingleField()
+    {
+        $testDoc = new MultipleHash();
+        $testDoc->setFirstname('Tommy');
+        $testDoc->setLastname('Hatchling');
+
+        $this->hashHelper->hashField('firstname', $testDoc, $this->documentManager->getClassMetadata(get_class($testDoc)));
+
+        $this->assertNotEquals('Tommy', $testDoc->getFirstname());
+        $this->assertEquals('Hatchling', $testDoc->getLastname());
+    }
+}

--- a/tests/Zoop/Shard/Test/Crypt/HashHelperTest.php
+++ b/tests/Zoop/Shard/Test/Crypt/HashHelperTest.php
@@ -49,7 +49,11 @@ class HashHelperTest extends BaseTest
         $testDoc->setFirstname('Tommy');
         $testDoc->setLastname('Hatchling');
 
-        $this->hashHelper->hashField('firstname', $testDoc, $this->documentManager->getClassMetadata(get_class($testDoc)));
+        $this->hashHelper->hashField(
+            'firstname',
+            $testDoc,
+            $this->documentManager->getClassMetadata(get_class($testDoc))
+        );
 
         $this->assertNotEquals('Tommy', $testDoc->getFirstname());
         $this->assertEquals('Hatchling', $testDoc->getLastname());

--- a/tests/Zoop/Shard/Test/Crypt/TestAsset/Document/MultipleBlockCipher.php
+++ b/tests/Zoop/Shard/Test/Crypt/TestAsset/Document/MultipleBlockCipher.php
@@ -7,7 +7,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Zoop\Shard\Annotation\Annotations as Shard;
 
 /** @ODM\Document */
-class CryptValidatorDoc
+class MultipleBlockCipher
 {
     /**
      * @ODM\Id(strategy="UUID")
@@ -17,38 +17,37 @@ class CryptValidatorDoc
     /**
      * @ODM\String
      * @Shard\Crypt\BlockCipher(key = "testkey")
-     * @Shard\Validator\Email
      */
-    protected $email;
+    protected $firstname;
 
     /**
-     *
      * @ODM\String
+     * @Shard\Crypt\BlockCipher(key = "testkey")
      */
-    protected $name;
+    protected $lastname;
 
     public function getId()
     {
         return $this->id;
     }
 
-    public function getEmail()
+    public function getFirstname()
     {
-        return $this->email;
+        return $this->firstname;
     }
 
-    public function setEmail($email)
+    public function setFirstname($firstname)
     {
-        $this->email = $email;
+        $this->firstname = $firstname;
     }
 
-    public function getName()
+    public function getLastname()
     {
-        return $this->name;
+        return $this->lastname;
     }
 
-    public function setName($name)
+    public function setLastname($lastname)
     {
-        $this->name = $name;
+        $this->lastname = $lastname;
     }
 }

--- a/tests/Zoop/Shard/Test/Crypt/TestAsset/Document/MultipleHash.php
+++ b/tests/Zoop/Shard/Test/Crypt/TestAsset/Document/MultipleHash.php
@@ -7,7 +7,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Zoop\Shard\Annotation\Annotations as Shard;
 
 /** @ODM\Document */
-class CryptValidatorDoc
+class MultipleHash
 {
     /**
      * @ODM\Id(strategy="UUID")
@@ -16,39 +16,38 @@ class CryptValidatorDoc
 
     /**
      * @ODM\String
-     * @Shard\Crypt\BlockCipher(key = "testkey")
-     * @Shard\Validator\Email
+     * @Shard\Crypt\Hash(salt="testsalt")
      */
-    protected $email;
+    protected $firstname;
 
     /**
-     *
      * @ODM\String
+     * @Shard\Crypt\Hash(salt="testsalt")
      */
-    protected $name;
+    protected $lastname;
 
     public function getId()
     {
         return $this->id;
     }
 
-    public function getEmail()
+    public function getFirstname()
     {
-        return $this->email;
+        return $this->firstname;
     }
 
-    public function setEmail($email)
+    public function setFirstname($firstname)
     {
-        $this->email = $email;
+        $this->firstname = $firstname;
     }
 
-    public function getName()
+    public function getLastname()
     {
-        return $this->name;
+        return $this->lastname;
     }
 
-    public function setName($name)
+    public function setLastname($lastname)
     {
-        $this->name = $name;
+        $this->lastname = $lastname;
     }
 }

--- a/tests/Zoop/Shard/Test/Crypt/TestAsset/Salt.php
+++ b/tests/Zoop/Shard/Test/Crypt/TestAsset/Salt.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Zoop\Shard\Test\Crypt\TestAsset;
+
+use Zoop\Common\Crypt\SaltInterface;
+
+class Salt implements SaltInterface
+{
+    public function getSalt()
+    {
+        return 'test salt phrase';
+    }
+}

--- a/tests/Zoop/Shard/Test/ODMCore/ExceptionEventsAggregatorTest.php
+++ b/tests/Zoop/Shard/Test/ODMCore/ExceptionEventsAggregatorTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Zoop\Shard\Test\ODMCore;
+
+use Zoop\Shard\Manifest;
+use Zoop\Shard\Core\Events;
+use Zoop\Shard\Test\BaseTest;
+use Zoop\Shard\Test\ODMCore\TestAsset\Document\Simple;
+
+class ExceptionEventsAggregatorTest extends BaseTest
+{
+
+    protected $calls = [];
+
+    public function setUp()
+    {
+        $manifest = new Manifest(
+            [
+                'models' => [
+                    __NAMESPACE__ . '\TestAsset\Document' => __DIR__ . '/TestAsset/Document'
+                ],
+                'extension_configs' => [
+                    'extension.odmcore'   => true,
+                    'extension.validator' => true
+                ],
+            ]
+        );
+
+        $this->documentManager = $manifest->getServiceManager()->get('modelmanager');
+
+        $eventManager = $this->documentManager->getEventManager();
+        $eventManager->addEventListener(Events::EXCEPTION, $this);
+
+        $this->calls = [];
+    }
+
+    public function testInvalidCreate()
+    {
+        $documentManager = $this->documentManager;
+
+        $testDoc = new Simple();
+        $testDoc->setName('invalid');
+
+        $documentManager->persist($testDoc);
+        $documentManager->flush();
+
+        $this->assertTrue(isset($this->calls[Events::EXCEPTION]));
+        $this->assertCount(
+            2,
+            $this->calls[Events::EXCEPTION][0]->getInnerEvent()->getResult()->getFieldResults()['name']->getMessages()
+        );
+
+        $id = $testDoc->getId();
+        $documentManager->clear();
+
+        $repository = $documentManager->getRepository(get_class($testDoc));
+        $testDoc = $repository->find($id);
+
+        $this->assertNull($testDoc);
+    }
+
+    public function __call($name, $arguments)
+    {
+        $this->calls[$name] = $arguments;
+    }
+}

--- a/tests/Zoop/Shard/Test/ODMCore/ExceptionEventsAggregatorTest.php
+++ b/tests/Zoop/Shard/Test/ODMCore/ExceptionEventsAggregatorTest.php
@@ -45,6 +45,7 @@ class ExceptionEventsAggregatorTest extends BaseTest
         $documentManager->flush();
 
         $this->assertTrue(isset($this->calls[Events::EXCEPTION]));
+        $this->assertEquals('invalidModel', $this->calls[Events::EXCEPTION][0]->getName());
         $this->assertCount(
             2,
             $this->calls[Events::EXCEPTION][0]->getInnerEvent()->getResult()->getFieldResults()['name']->getMessages()

--- a/tests/Zoop/Shard/Test/ODMCore/MultipleConnectionTest.php
+++ b/tests/Zoop/Shard/Test/ODMCore/MultipleConnectionTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Zoop\Shard\Test\ODMCore;
+
+use Zoop\Shard\Manifest;
+use Zoop\Shard\Test\BaseTest;
+use Zoop\Shard\Test\ODMCore\TestAsset\Document\Album;
+
+class MultipleConnectionTest extends BaseTest
+{
+
+    public function testMultipleConnections()
+    {
+        $manifest1 = new Manifest(
+            [
+                'models' => [
+                    __NAMESPACE__ . '\TestAsset\Document' => __DIR__ . '/TestAsset/Document'
+                ],
+                'extension_configs' => [
+                    'extension.odmcore'   => [
+                        'default_db' => 'shard-phpunit-1'
+                    ],
+                ],
+            ]
+        );
+
+        $manifest2 = new Manifest(
+            [
+                'models' => [
+                    __NAMESPACE__ . '\TestAsset\Document' => __DIR__ . '/TestAsset/Document'
+                ],
+                'extension_configs' => [
+                    'extension.odmcore'   => [
+                        'default_db' => 'shard-phpunit-2'
+                    ],
+                ],
+            ]
+        );
+
+        $documentManager1 = $manifest1->getServiceManager()->get('modelmanager');
+        $documentManager2 = $manifest2->getServiceManager()->get('modelmanager');
+
+        $album1 = new Album('Ivy and the big apples');
+        $album2 = new Album('Guide to better living');
+
+        $documentManager1->persist($album1);
+        $documentManager2->persist($album2);
+
+        $documentManager1->flush();
+        $documentManager2->flush();
+
+        $albums1 = $documentManager1->getRepository(get_class($album1))->findAll();
+        $this->assertCount(1, $albums1);
+        $this->assertEquals('Ivy and the big apples', $albums1[0]->getName());
+
+        $albums2 = $documentManager2->getRepository(get_class($album2))->findAll();
+        $this->assertCount(1, $albums2);
+        $this->assertEquals('Guide to better living', $albums2[0]->getName());
+
+        //cleanup
+        foreach ($documentManager1->getConnection()->selectDatabase('shard-phpunit-1')->listCollections() as $collection) {
+            $collection->remove(array(), array('safe' => true));
+        }
+        foreach ($documentManager2->getConnection()->selectDatabase('shard-phpunit-2')->listCollections() as $collection) {
+            $collection->remove(array(), array('safe' => true));
+        }
+    }
+}

--- a/tests/Zoop/Shard/Test/ODMCore/MultipleConnectionTest.php
+++ b/tests/Zoop/Shard/Test/ODMCore/MultipleConnectionTest.php
@@ -58,10 +58,13 @@ class MultipleConnectionTest extends BaseTest
         $this->assertEquals('Guide to better living', $albums2[0]->getName());
 
         //cleanup
-        foreach ($documentManager1->getConnection()->selectDatabase('shard-phpunit-1')->listCollections() as $collection) {
+        $collections = $documentManager1->getConnection()->selectDatabase('shard-phpunit-1')->listCollections();
+        foreach ($collections as $collection) {
             $collection->remove(array(), array('safe' => true));
         }
-        foreach ($documentManager2->getConnection()->selectDatabase('shard-phpunit-2')->listCollections() as $collection) {
+
+        $collections = $documentManager2->getConnection()->selectDatabase('shard-phpunit-2')->listCollections();
+        foreach ($collections as $collection) {
             $collection->remove(array(), array('safe' => true));
         }
     }

--- a/tests/Zoop/Shard/Test/ODMCore/TestAsset/Document/Simple.php
+++ b/tests/Zoop/Shard/Test/ODMCore/TestAsset/Document/Simple.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Zoop\Shard\Test\ODMCore\TestAsset\Document;
+
+//Annotaion imports
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Zoop\Shard\Annotation\Annotations as Shard;
+
+/**
+ * @ODM\Document
+ * @Shard\Validator(class = "Zoop\Shard\Test\Validator\TestAsset\ClassValidator")
+ */
+class Simple
+{
+    /**
+     * @ODM\Id(strategy="UUID")
+     */
+    protected $id;
+
+    /**
+     * @ODM\String
+     * @Shard\Validator\Chain({
+     *     @Shard\Validator\Required,
+     *     @Shard\Validator(class = "Zoop\Shard\Test\Validator\TestAsset\FieldValidator1"),
+     *     @Shard\Validator(class = "Zoop\Shard\Test\Validator\TestAsset\FieldValidator2")
+     * })
+     */
+    protected $name;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+}


### PR DESCRIPTION
- Add Exception Event Aggregator. Now, when there is an exception like event called, the agregator will catch all of them and raise an `exception` event. This means you only need to subscribe to one event, rather than lots, to see what might have gone wrong in a flush.
- Add test/example for multiple connections
- Add more `encryptField` and `decryptField` to crypt helper.
