### PR TITLE
Unserialize Nested Abstract Embeds

### DIFF
--- a/lib/Zoop/Shard/Serializer/Unserializer.php
+++ b/lib/Zoop/Shard/Serializer/Unserializer.php
@@ -231,7 +231,7 @@ class Unserializer implements ServiceLocatorAwareInterface, ModelManagerAwareInt
             $mapping['discriminatorField'] :
             '_doctrine_class_name';
             $targetClass = $mapping['discriminatorMap'][$data[$discriminatorField]];
-        } elseif(isset($mapping['targetDocument']) && class_exists($mapping['targetDocument'])) {
+        } elseif (isset($mapping['targetDocument']) && class_exists($mapping['targetDocument'])) {
             $targetClass = $mapping['targetDocument'];
         } else {
             $targetClass = $metadata->getAssociationTargetClass($field);

--- a/lib/Zoop/Shard/Serializer/Unserializer.php
+++ b/lib/Zoop/Shard/Serializer/Unserializer.php
@@ -231,6 +231,8 @@ class Unserializer implements ServiceLocatorAwareInterface, ModelManagerAwareInt
             $mapping['discriminatorField'] :
             '_doctrine_class_name';
             $targetClass = $mapping['discriminatorMap'][$data[$discriminatorField]];
+        } elseif(isset($mapping['targetDocument']) && class_exists($mapping['targetDocument'])) {
+            $targetClass = $mapping['targetDocument'];
         } else {
             $targetClass = $metadata->getAssociationTargetClass($field);
         }

--- a/tests/Zoop/Shard/Test/BaseTest.php
+++ b/tests/Zoop/Shard/Test/BaseTest.php
@@ -14,7 +14,7 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
                 ->selectDatabase('zoop-shard')->listCollections();
 
             foreach ($collections as $collection) {
-                $collection->remove(array(), array('safe' => true));
+                $collection->remove();
             }
         }
     }

--- a/tests/Zoop/Shard/Test/ODMCore/MultipleConnectionTest.php
+++ b/tests/Zoop/Shard/Test/ODMCore/MultipleConnectionTest.php
@@ -60,12 +60,12 @@ class MultipleConnectionTest extends BaseTest
         //cleanup
         $collections = $documentManager1->getConnection()->selectDatabase('shard-phpunit-1')->listCollections();
         foreach ($collections as $collection) {
-            $collection->remove(array(), array('safe' => true));
+            $collection->remove();
         }
 
         $collections = $documentManager2->getConnection()->selectDatabase('shard-phpunit-2')->listCollections();
         foreach ($collections as $collection) {
-            $collection->remove(array(), array('safe' => true));
+            $collection->remove();
         }
     }
 }

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/Order/AbstractItem.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/Order/AbstractItem.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Zoop\Shard\Test\Serializer\TestAsset\Document\Order;
+
+//Annotation imports
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Zoop\Shard\Annotation\Annotations as Shard;
+
+/**
+ * @ODM\EmbeddedDocument
+ */
+abstract class AbstractItem
+{
+    /**
+     * @ODM\String
+     */
+    protected $brand;
+    
+    /**
+     * @ODM\String
+     * @Shard\Validator\Required
+     */
+    protected $name;
+
+    /**
+     * @ODM\EmbedOne(targetDocument="Price")
+     */
+    protected $price;
+
+    /**
+     * @ODM\Int
+     */
+    protected $quantity;
+
+    /**
+     * @return string
+     */
+    public function getBrand()
+    {
+        return $this->brand;
+    }
+
+    /**
+     * @param string $brand
+     */
+    public function setBrand($brand)
+    {
+        $this->brand = $brand;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return Price
+     */
+    public function getPrice()
+    {
+        return $this->price;
+    }
+
+    /**
+     * @param Price $price
+     */
+    public function setPrice(Price $price)
+    {
+        $this->price = $price;
+    }
+
+    /**
+     * @return integer
+     */
+    public function getQuantity()
+    {
+        return $this->quantity;
+    }
+
+    /**
+     * @param integer $quantity
+     */
+    public function setQuantity($quantity)
+    {
+        $this->quantity = (int) $quantity;
+    }
+}

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/Order/Bundle.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/Order/Bundle.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Zoop\Shard\Test\Serializer\TestAsset\Document\Order;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Zoop\Shard\Test\Serializer\TestAsset\Document\Order\SingleItem;
+
+//Annotation imports
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Zoop\Shard\Annotation\Annotations as Shard;
+
+/**
+ * @ODM\EmbeddedDocument
+ */
+class Bundle
+{
+    /**
+     * @ODM\String
+     * @Shard\Validator\Required
+     */
+    protected $name;
+
+    /**
+     * @ODM\EmbedOne(targetDocument="Price")
+     */
+    protected $price;
+    
+    /**
+     *
+     * @ODM\EmbedMany(targetDocument="SingleItem")
+     */
+    protected $items;
+
+    public function __construct()
+    {
+        $this->items = new ArrayCollection();
+    }
+
+    /**
+     * @param AbstractItem $item
+     */
+    public function addItem(SingleItem $item)
+    {
+        $this->getItems()->add($item);
+    }
+
+    /**
+     * @return ArrayCollection
+     */
+    public function getItems()
+    {
+        return $this->items;
+    }
+
+    /**
+     * @param ArrayCollection $items
+     */
+    public function setItems($items)
+    {
+        $this->items = $items;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return Price
+     */
+    public function getPrice()
+    {
+        return $this->price;
+    }
+
+    /**
+     * @param Price $price
+     */
+    public function setPrice(Price $price)
+    {
+        $this->price = $price;
+    }
+}

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/Order/DigitalSku.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/Order/DigitalSku.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Zoop\Shard\Test\Serializer\TestAsset\Document\Order;
+
+//Annotation imports
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Zoop\Shard\Annotation\Annotations as Shard;
+
+/**
+ * @ODM\EmbeddedDocument
+ */
+class DigitalSku
+{
+    /**
+     *
+     * @ODM\String
+     */
+    protected $file;
+
+    /**
+     *
+     * @ODM\Int
+     */
+    protected $numberOfDownloads = 0;
+
+
+    /**
+     *
+     * @return integer
+     */
+    public function getNumberOfDownloads()
+    {
+        return $this->numberOfDownloads;
+    }
+
+    /**
+     *
+     * @param integer $numberOfDownloads
+     */
+    public function setNumberOfDownloads($numberOfDownloads)
+    {
+        $this->numberOfDownloads = (int) $numberOfDownloads;
+    }
+
+    /**
+     * Increases the download count
+     */
+    public function incrementNumberOfDownloads()
+    {
+        $this->numberOfDownloads++;
+    }
+
+    /**
+     * Decreases the download count
+     */
+    public function decrementNumberOfDownloads()
+    {
+        if ($this->numberOfDownloads > 0) {
+            $this->numberOfDownloads--;
+        }
+    }
+
+    /**
+     *
+     * @return string
+     */
+    public function getFile()
+    {
+        return $this->file;
+    }
+
+    /**
+     *
+     * @param string $file
+     */
+    public function setFile($file)
+    {
+        $this->file = $file;
+    }
+}

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/Order/Dimensions.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/Order/Dimensions.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Zoop\Shard\Test\Serializer\TestAsset\Document\Order;
+
+//Annotation imports
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Zoop\Shard\Annotation\Annotations as Shard;
+
+/**
+ * @ODM\EmbeddedDocument
+ */
+class Dimensions
+{
+    /**
+     *
+     * @ODM\Float
+     */
+    protected $weight;
+
+    /**
+     *
+     * @ODM\Float
+     */
+    protected $width;
+
+    /**
+     *
+     * @ODM\Float
+     */
+    protected $height;
+
+    /**
+     *
+     * @ODM\Float
+     */
+    protected $depth;
+
+    /**
+     *
+     * @return float
+     */
+    public function getWeight()
+    {
+        return $this->weight;
+    }
+
+    /**
+     *
+     * @param float $weight
+     */
+    public function setWeight($weight)
+    {
+        $this->weight = (float) $weight;
+    }
+
+    /**
+     *
+     * @return float
+     */
+    public function getWidth()
+    {
+        return $this->width;
+    }
+
+    /**
+     *
+     * @param float $width
+     */
+    public function setWidth($width)
+    {
+        $this->width = (float) $width;
+    }
+
+    /**
+     *
+     * @return float
+     */
+    public function getHeight()
+    {
+        return $this->height;
+    }
+
+    /**
+     *
+     * @param float $height
+     */
+    public function setHeight($height)
+    {
+        $this->height = (float) $height;
+    }
+
+    /**
+     *
+     * @return float
+     */
+    public function getDepth()
+    {
+        return $this->depth;
+    }
+
+    /**
+     *
+     * @param float $depth
+     */
+    public function setDepth($depth)
+    {
+        $this->depth = (float) $depth;
+    }
+}

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/Order/Order.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/Order/Order.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Zoop\Shard\Test\Serializer\TestAsset\Document\Order;
+
+//Annotation imports
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Zoop\Shard\Annotation\Annotations as Shard;
+
+/**
+ * @ODM\Document
+ */
+class Order
+{
+    /**
+     * @ODM\Id(strategy="UUID")
+     */
+    protected $id;
+
+    /**
+     *
+     * @ODM\String
+     */
+    protected $name;
+
+    /**
+     *
+     * @ODM\EmbedMany(
+     *     discriminatorField="type",
+     *     discriminatorMap={
+     *         "SingleItem"     = "SingleItem",
+     *         "Bundle"         = "Bundle"
+     *     }
+     * )
+     */
+    protected $items;
+
+    /**
+     *
+     * @ODM\EmbedOne(targetDocument="Total")
+     */
+    protected $total;
+    
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function getItems()
+    {
+        return $this->items;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function setItems($items)
+    {
+        $this->items = $items;
+    }
+
+    /**
+     *
+     * @return Total
+     */
+    public function getTotal()
+    {
+        return $this->total;
+    }
+
+    /**
+     *
+     * @param Total $total
+     */
+    public function setTotal(Total $total)
+    {
+        $this->total = $total;
+    }
+}

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/Order/PhysicalSku.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/Order/PhysicalSku.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Zoop\Shard\Test\Serializer\TestAsset\Document\Order;
+
+//Annotation imports
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Zoop\Shard\Annotation\Annotations as Shard;
+
+/**
+ * @ODM\EmbeddedDocument
+ */
+class PhysicalSku
+{
+    /**
+     * @ODM\EmbedOne(targetDocument="Dimensions")
+     */
+    protected $dimensions;
+
+    /**
+     * @return Dimensions
+     */
+    public function getDimensions()
+    {
+        return $this->dimensions;
+    }
+
+    /**
+     * @param Dimensions $dimensions
+     */
+    public function setDimensions(Dimensions $dimensions)
+    {
+        $this->dimensions = $dimensions;
+    }
+}

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/Order/Price.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/Order/Price.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Zoop\Shard\Test\Serializer\TestAsset\Document\Order;
+
+//Annotation imports
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Zoop\Shard\Annotation\Annotations as Shard;
+
+/**
+ * @ODM\EmbeddedDocument
+ */
+class Price
+{
+    /**
+     * Wholesale price per unit
+     * 
+     * @ODM\Float
+     */
+    protected $wholesale;
+
+    /**
+     * List price per unit
+     * 
+     * @ODM\Float
+     */
+    protected $list;
+
+    /**
+     * List x Quantity
+     * 
+     * @ODM\Float
+     */
+    protected $subTotal;
+
+    /**
+     * Discount per unit
+     * 
+     * @ODM\Float
+     */
+    protected $discount;
+
+    /**
+     * (List x Quantity) - (Discount x Quantity)
+     * 
+     * @ODM\Float
+     */
+    protected $total;
+
+    /**
+     * Tax included per unit
+     * 
+     * @ODM\Float
+     */
+    protected $taxIncluded;
+
+    /**
+     * Shipping cost per unit (not included in total)
+     * 
+     * @ODM\Float
+     */
+    protected $shipping;
+
+    /**
+     * Wholesale price per unit
+     * 
+     * @return float
+     */
+    public function getWholesale()
+    {
+        return $this->wholesale;
+    }
+
+    /**
+     *
+     * @param float $wholesale
+     */
+    public function setWholesale($wholesale)
+    {
+        $this->wholesale = (float) $wholesale;
+    }
+
+    /**
+     * List price per unit
+     * @return float
+     */
+    public function getList()
+    {
+        return $this->list;
+    }
+
+    /**
+     *
+     * @param float $list
+     */
+    public function setList($list)
+    {
+        $this->list = (float) $list;
+    }
+
+    /**
+     * List x Quantity
+     * 
+     * @return float
+     */
+    public function getSubTotal()
+    {
+        return $this->subTotal;
+    }
+
+    /**
+     *
+     * @param float $subTotal
+     */
+    public function setSubTotal($subTotal)
+    {
+        $this->subTotal = (float) $subTotal;
+    }
+
+    /**
+     * Discount per unit
+     * 
+     * @return float
+     */
+    public function getDiscount()
+    {
+        return $this->discount;
+    }
+
+    /**
+     *
+     * @param float $discount
+     */
+    public function setDiscount($discount)
+    {
+        $this->discount = (float) $discount;
+    }
+
+    /**
+     *
+     * @return float
+     */
+    public function getTotal()
+    {
+        return $this->total;
+    }
+
+    /**
+     * (List x Quantity) - (Discount x Quantity)
+     * 
+     * @param float $total
+     */
+    public function setTotal($total)
+    {
+        $this->total = (float) $total;
+    }
+
+    /**
+     * Tax included per unit
+     * 
+     * @return float
+     */
+    public function getTaxIncluded()
+    {
+        return $this->taxIncluded;
+    }
+
+    /**
+     *
+     * @param float $taxIncluded
+     */
+    public function setTaxIncluded($taxIncluded)
+    {
+        $this->taxIncluded = (float) $taxIncluded;
+    }
+
+    /**
+     * Shipping cost per unit (not included in total)
+     * 
+     * @return float
+     */
+    public function getShipping()
+    {
+        return $this->shipping;
+    }
+
+    /**
+     *
+     * @param float $shipping
+     */
+    public function setShipping($shipping)
+    {
+        $this->shipping = (float) $shipping;
+    }
+}

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/Order/SingleItem.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/Order/SingleItem.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Zoop\Shard\Test\Serializer\TestAsset\Document\Order;
+
+//Annotation imports
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Zoop\Shard\Annotation\Annotations as Shard;
+
+/**
+ * @ODM\EmbeddedDocument
+ */
+class SingleItem extends AbstractItem
+{
+    /**
+     *
+     * @ODM\String
+     */
+    protected $name;
+    
+    /**
+     * @ODM\EmbedOne(
+     *      discriminatorField="type",
+     *      discriminatorMap={
+     *         "PhysicalSku"    = "PhysicalSku",
+     *         "DigitalSku"     = "DigitalSku"
+     *      }
+     * )
+     */
+    protected $sku;
+
+    /**
+     * @return PhysicalSku|DigitalSku
+     */
+    public function getSku()
+    {
+        return $this->sku;
+    }
+
+    /**
+     * @param PhysicalSku|DigitalSku $sku
+     */
+    public function setSku($sku)
+    {
+        $this->sku = $sku;
+    }
+    
+    /**
+     * 
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * 
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/Order/Total.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/Order/Total.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Zoop\Shard\Test\Serializer\TestAsset\Document\Order;
+
+//Annotation imports
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Zoop\Shard\Annotation\Annotations as Shard;
+
+/**
+ * @ODM\EmbeddedDocument
+ */
+class Total
+{
+    /**
+     *
+     * @ODM\Float
+     */
+    protected $shippingPrice;
+
+    /**
+     *
+     * @ODM\Float
+     */
+    protected $productWholesalePrice;
+
+    /**
+     *
+     * @ODM\Float
+     */
+    protected $productListPrice;
+
+    /**
+     *
+     * @ODM\Int
+     */
+    protected $productQuantity;
+
+    /**
+     *
+     * @ODM\Float
+     */
+    protected $discountPrice;
+
+    /**
+     *
+     * @ODM\Float
+     */
+    protected $taxIncluded;
+
+    /**
+     *
+     * @ODM\Float
+     */
+    protected $orderPrice;
+
+    /**
+     *
+     * @return float
+     */
+    public function getShippingPrice()
+    {
+        return $this->shippingPrice;
+    }
+
+    /**
+     *
+     * @param float $shippingPrice
+     */
+    public function setShippingPrice($shippingPrice)
+    {
+        $this->shippingPrice = (float) $shippingPrice;
+    }
+
+    /**
+     * @return float
+     */
+    public function getProductWholesalePrice()
+    {
+        return $this->productWholesalePrice;
+    }
+
+    /**
+     * @param float $productWholesalePrice
+     */
+    public function setProductWholesalePrice($productWholesalePrice)
+    {
+        $this->productWholesalePrice = (float) $productWholesalePrice;
+    }
+
+    /**
+     * @return float
+     */
+    public function getProductListPrice()
+    {
+        return $this->productListPrice;
+    }
+
+    /**
+     * @param float $productListPrice
+     */
+    public function setProductListPrice($productListPrice)
+    {
+        $this->productListPrice = $productListPrice;
+    }
+
+    /**
+     * @return float
+     */
+    public function getTaxIncluded()
+    {
+        return $this->taxIncluded;
+    }
+
+    /**
+     * @param float $taxIncluded
+     */
+    public function setTaxIncluded($taxIncluded)
+    {
+        $this->taxIncluded = (float) $taxIncluded;
+    }
+
+    /**
+     *
+     * @return integer
+     */
+    public function getProductQuantity()
+    {
+        return $this->productQuantity;
+    }
+
+    /**
+     *
+     * @param integer $productQuantity
+     */
+    public function setProductQuantity($productQuantity)
+    {
+        $this->productQuantity = (int) $productQuantity;
+    }
+
+    /**
+     *
+     * @return float
+     */
+    public function getDiscountPrice()
+    {
+        return $this->discountPrice;
+    }
+
+    /**
+     *
+     * @param float $discountPrice
+     */
+    public function setDiscountPrice($discountPrice)
+    {
+        $this->discountPrice = (float) $discountPrice;
+    }
+
+    /**
+     *
+     * @return float
+     */
+    public function getOrderPrice()
+    {
+        return $this->orderPrice;
+    }
+
+    /**
+     *
+     * @param float $orderPrice
+     */
+    public function setOrderPrice($orderPrice)
+    {
+        $this->orderPrice = (float) $orderPrice;
+    }
+}

--- a/tests/Zoop/Shard/Test/Serializer/UnserializerTest.php
+++ b/tests/Zoop/Shard/Test/Serializer/UnserializerTest.php
@@ -5,6 +5,10 @@ namespace Zoop\Shard\Test\Serializer;
 use Zoop\Shard\Manifest;
 use Zoop\Shard\Test\BaseTest;
 use Zoop\Shard\Test\Serializer\TestAsset\Document\User;
+use Zoop\Shard\Test\Serializer\TestAsset\Document\Order\Order;
+use Zoop\Shard\Test\Serializer\TestAsset\Document\Order\SingleItem;
+use Zoop\Shard\Test\Serializer\TestAsset\Document\Order\Bundle;
+use Zoop\Shard\Test\Serializer\TestAsset\Document\Order\PhysicalSku;
 
 class UnserializerTest extends BaseTest
 {
@@ -57,5 +61,76 @@ class UnserializerTest extends BaseTest
         $this->assertEquals('groupB', $user->getGroups()[1]->getName());
         $this->assertEquals('Tim', $user->getProfile()->getFirstname());
         $this->assertEquals('Roediger', $user->getProfile()->getLastname());
+    }
+
+    public function testNestedAbstractEmbedUnserializer()
+    {
+        $data = array(
+            'name' => 'crimsonronin',
+            'items' => array(
+                array(
+                    'type' => 'SingleItem',
+                    'name' => 'LG 22" Monitor',
+                    'price' => array(
+                        'wholesale' => 150,
+                        'list' => 200,
+                        'subTotal' => 200,
+                        'discount' => 10,
+                        'total' => 190,
+                        'taxIncluded' => 10,
+                        'shipping' => 10,
+                    ),
+                    'sku' => array(
+                        'type' => 'PhysicalSku',
+                        'dimensions' => array(
+                            'width' => 22,
+                            'height' => 30,
+                            'depth' => 5,
+                            'weight' => 10,
+                        )
+                    )
+                ),
+                array(
+                    'type' => 'Bundle',
+                    'name' => 'Logitech Keyboard',
+                    'price' => array(
+                        'wholesale' => 10,
+                        'list' => 50,
+                        'subTotal' => 50,
+                        'discount' => 0,
+                        'total' => 50,
+                        'taxIncluded' => 5,
+                        'shipping' => 2,
+                    )
+                )
+            ),
+            'total' => array(
+                'shippingPrice' => 12,
+                'productWholesalePrice' => 160,
+                'productListPrice' => 250,
+                'productQuantity' => 2,
+                'discountPrice' => 10,
+                'taxIncluded' => 15,
+                'orderPrice' => 252
+            )
+        );
+
+        $order = $this->unserializer->fromArray(
+            $data,
+            'Zoop\Shard\Test\Serializer\TestAsset\Document\Order\Order'
+        );
+        
+        $this->assertTrue($order instanceof Order);
+        $this->assertEquals('crimsonronin', $order->getName());
+        $this->assertCount(2, $order->getItems());
+        
+        $single = $order->getItems()[0];
+        $this->assertTrue($single instanceof SingleItem);
+        $this->assertEquals(150, $single->getPrice()->getWholesale());
+        $this->assertTrue($single->getSku() instanceof PhysicalSku);
+        
+        $bundle = $order->getItems()[1];
+        $this->assertTrue($bundle instanceof Bundle);
+        $this->assertEquals(10, $bundle->getPrice()->getWholesale());
     }
 }


### PR DESCRIPTION
I'm not sure why this is happening (ie. the root cause), however when I have an `EmbedMany` with a `discriminatorMap`, and those classes inherit from an abstract class which also has an `embed`, I get the following error:

```
InvalidArgumentException: Association name expected, 'price' is not an association.
```

See https://github.com/crimsonronin/shard/blob/f95b5b2a67c7e3cc74181f778c2a1dc524b64510/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/Order/Order.php#L35

Adding the [following](https://github.com/crimsonronin/shard/blob/f95b5b2a67c7e3cc74181f778c2a1dc524b64510/lib/Zoop/Shard/Serializer/Unserializer.php#L234) to `Unserializer` fixes the issue:

``` php
} elseif(isset($mapping['targetDocument']) && class_exists($mapping['targetDocument'])) {
    $targetClass = $mapping['targetDocument'];
} else {
```

Not sure if this is just a bandaid, or the proper fix. Any suggestions @superdweebie?
