### PR TITLE
EmbedOne with discriminator field/map.

### DIFF
--- a/build/bin/csmd.sh
+++ b/build/bin/csmd.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./vendor/bin/phpmd --exclude ClassMetadataTrait.php ./lib/ ./tests/text ./tests/ruleset.xml
+./vendor/bin/phpmd --exclude ClassMetadataTrait.php ./lib/ text ./tests/ruleset.xml

--- a/tests/Zoop/Shard/Test/ODMCore/ClassMetadataTest.php
+++ b/tests/Zoop/Shard/Test/ODMCore/ClassMetadataTest.php
@@ -16,7 +16,6 @@ class ClassMetadataTest extends BaseTest
                     __NAMESPACE__ . '\TestAsset\Document' => __DIR__ . '/TestAsset/Document'
                 ],
                 'extension_configs' => [
-                'extension.serializer' => true,
                     'extension.odmcore' => true
                 ],
             ]

--- a/tests/Zoop/Shard/Test/ODMCore/ClassMetadataTest.php
+++ b/tests/Zoop/Shard/Test/ODMCore/ClassMetadataTest.php
@@ -8,7 +8,6 @@ use Zoop\Shard\Test\BaseTest;
 
 class ClassMetadataTest extends BaseTest
 {
-
     public function setUp()
     {
         $manifest = new Manifest(
@@ -17,6 +16,7 @@ class ClassMetadataTest extends BaseTest
                     __NAMESPACE__ . '\TestAsset\Document' => __DIR__ . '/TestAsset/Document'
                 ],
                 'extension_configs' => [
+                'extension.serializer' => true,
                     'extension.odmcore' => true
                 ],
             ]

--- a/tests/Zoop/Shard/Test/ODMCore/PreLoadTest.php
+++ b/tests/Zoop/Shard/Test/ODMCore/PreLoadTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Zoop\Shard\Test\ODMCore;
+
+use Zoop\Shard\Manifest;
+use Zoop\Shard\Test\ODMCore\TestAsset\Document\Album;
+use Zoop\Shard\Test\ODMCore\TestAsset\Document\Artist;
+use Zoop\Shard\Test\ODMCore\TestAsset\Document\RecordLabel;
+use Zoop\Shard\Test\ODMCore\TestAsset\Document\Song;
+use Zoop\Shard\Test\BaseTest;
+
+class PreLoadTest extends BaseTest
+{
+    public function setUp()
+    {
+        $manifest = new Manifest(
+            [
+                'models' => [
+                    __NAMESPACE__ . '\TestAsset\Document' => __DIR__ . '/TestAsset/Document'
+                ],
+                'extension_configs' => [
+                    'extension.odmcore' => true
+                ],
+            ]
+        );
+
+        $this->documentManager = $manifest->getServiceManager()->get('modelmanager');
+    }
+
+    public function testGetEmbeddedOneWithDiscriminator()
+    {
+        $license1 = new Artist('Pearl Jam');
+        $license2 = new RecordLabel('Epic Records');
+
+        //create and persist a document
+        $document = new Album('Ten');
+        $document->addSong(new Song('Once', $license1));
+        $document->addSong(new Song('Even Flow', $license2));
+        $document->addSong(new Song('Alive', $license2));
+
+        $this->documentManager->persist($document);
+        $this->documentManager->flush();
+        $this->documentManager->clear();
+        $id = $document->getId();
+        unset($document);
+        //get the proxy
+        $document = $this->documentManager
+            ->getRepository('Zoop\Shard\Test\ODMCore\TestAsset\Document\Album')
+            ->find($id);
+
+        $this->assertTrue($document instanceof Album);
+        $this->assertEquals('Ten', $document->getName());
+
+        $songs = $document->getSongs();
+        $this->assertCount(3, $songs);
+
+        $song = $songs[0];
+        $this->assertTrue($song instanceof Song);
+        $this->assertEquals('Once', $song->getName());
+        $license = $song->getLicense();
+        $this->assertTrue($license instanceof Artist);
+        $this->assertEquals('Pearl Jam', $license->getName());
+
+        $song = $songs[1];
+        $this->assertTrue($song instanceof Song);
+        $this->assertEquals('Even Flow', $song->getName());
+        $license = $song->getLicense();
+        $this->assertTrue($license instanceof RecordLabel);
+        $this->assertEquals('Epic Records', $license->getName());
+    }
+}

--- a/tests/Zoop/Shard/Test/ODMCore/PreLoadTest.php
+++ b/tests/Zoop/Shard/Test/ODMCore/PreLoadTest.php
@@ -27,7 +27,7 @@ class PreLoadTest extends BaseTest
         $this->documentManager = $manifest->getServiceManager()->get('modelmanager');
     }
 
-    public function testGetEmbeddedOneWithDiscriminator()
+    public function testEmbedOneWithDiscriminatorMap()
     {
         $license1 = new Artist('Pearl Jam');
         $license2 = new RecordLabel('Epic Records');

--- a/tests/Zoop/Shard/Test/ODMCore/TestAsset/Document/Album.php
+++ b/tests/Zoop/Shard/Test/ODMCore/TestAsset/Document/Album.php
@@ -2,8 +2,10 @@
 
 namespace Zoop\Shard\Test\ODMCore\TestAsset\Document;
 
+use Doctrine\Common\Collections\ArrayCollection;
 //Annotation imports
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Zoop\Shard\Annotation\Annotations as Shard;
 
 /** @ODM\Document */
 class Album
@@ -17,6 +19,17 @@ class Album
      * @ODM\String
      */
     protected $name;
+
+    /**
+     * @ODM\EmbedMany(targetDocument="\Zoop\Shard\Test\ODMCore\TestAsset\Document\Song")
+     */
+    protected $songs;
+
+    public function __construct($name)
+    {
+        $this->songs = new ArrayCollection;
+        $this->name = $name;
+    }
 
     /**
      * @return string
@@ -42,8 +55,27 @@ class Album
         $this->name = $name;
     }
 
-    public function __construct($name)
+    /**
+     * @return ArrayCollection
+     */
+    public function getSongs()
     {
-        $this->name = $name;
+        return $this->songs;
+    }
+
+    /**
+     * @param ArrayCollection $songs
+     */
+    public function setSongs($songs)
+    {
+        $this->songs = $songs;
+    }
+
+    /**
+     * @param Song $song
+     */
+    public function addSong(Song $song)
+    {
+        $this->getSongs()->add($song);
     }
 }

--- a/tests/Zoop/Shard/Test/ODMCore/TestAsset/Document/Artist.php
+++ b/tests/Zoop/Shard/Test/ODMCore/TestAsset/Document/Artist.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Zoop\Shard\Test\ODMCore\TestAsset\Document;
+
+//Annotation imports
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Zoop\Shard\Annotation\Annotations as Shard;
+
+/** @ODM\EmbeddedDocument */
+class Artist
+{
+    /**
+     * @ODM\String
+     */
+    protected $name;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/Zoop/Shard/Test/ODMCore/TestAsset/Document/RecordLabel.php
+++ b/tests/Zoop/Shard/Test/ODMCore/TestAsset/Document/RecordLabel.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Zoop\Shard\Test\ODMCore\TestAsset\Document;
+
+//Annotation imports
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Zoop\Shard\Annotation\Annotations as Shard;
+
+/** @ODM\EmbeddedDocument */
+class RecordLabel
+{
+    /**
+     * @ODM\String
+     */
+    protected $name;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/Zoop/Shard/Test/ODMCore/TestAsset/Document/Song.php
+++ b/tests/Zoop/Shard/Test/ODMCore/TestAsset/Document/Song.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Zoop\Shard\Test\ODMCore\TestAsset\Document;
+
+use Zoop\Shard\Test\ODMCore\TestAsset\Document\RecordLabel;
+use Zoop\Shard\Test\ODMCore\TestAsset\Document\Artist;
+//Annotation imports
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Zoop\Shard\Annotation\Annotations as Shard;
+
+/** @ODM\EmbeddedDocument */
+class Song
+{
+    /**
+     * @ODM\String
+     */
+    protected $name;
+
+    /**
+     * @ODM\EmbedOne(
+     *      discriminatorField="type",
+     *      discriminatorMap={
+     *         "RecordLabel"    = "Zoop\Shard\Test\ODMCore\TestAsset\Document\RecordLabel",
+     *         "Artist"         = "Zoop\Shard\Test\ODMCore\TestAsset\Document\Artist"
+     *      }
+     * )
+     */
+    protected $license;
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getLicense()
+    {
+        return $this->license;
+    }
+
+    public function setLicense($license)
+    {
+        $this->license = $license;
+    }
+
+    public function __construct($name, $license)
+    {
+        $this->name = $name;
+        $this->license = $license;
+    }
+}

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/Order/AbstractItem.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/Order/AbstractItem.php
@@ -15,7 +15,7 @@ abstract class AbstractItem
      * @ODM\String
      */
     protected $brand;
-    
+
     /**
      * @ODM\String
      * @Shard\Validator\Required

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/Order/Bundle.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/Order/Bundle.php
@@ -24,7 +24,7 @@ class Bundle
      * @ODM\EmbedOne(targetDocument="Price")
      */
     protected $price;
-    
+
     /**
      *
      * @ODM\EmbedMany(targetDocument="SingleItem")

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/Order/Order.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/Order/Order.php
@@ -39,7 +39,7 @@ class Order
      * @ODM\EmbedOne(targetDocument="Total")
      */
     protected $total;
-    
+
     public function getId()
     {
         return $this->id;

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/Order/Price.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/Order/Price.php
@@ -13,56 +13,56 @@ class Price
 {
     /**
      * Wholesale price per unit
-     * 
+     *
      * @ODM\Float
      */
     protected $wholesale;
 
     /**
      * List price per unit
-     * 
+     *
      * @ODM\Float
      */
     protected $list;
 
     /**
      * List x Quantity
-     * 
+     *
      * @ODM\Float
      */
     protected $subTotal;
 
     /**
      * Discount per unit
-     * 
+     *
      * @ODM\Float
      */
     protected $discount;
 
     /**
      * (List x Quantity) - (Discount x Quantity)
-     * 
+     *
      * @ODM\Float
      */
     protected $total;
 
     /**
      * Tax included per unit
-     * 
+     *
      * @ODM\Float
      */
     protected $taxIncluded;
 
     /**
      * Shipping cost per unit (not included in total)
-     * 
+     *
      * @ODM\Float
      */
     protected $shipping;
 
     /**
      * Wholesale price per unit
-     * 
+     *
      * @return float
      */
     public function getWholesale()
@@ -99,7 +99,7 @@ class Price
 
     /**
      * List x Quantity
-     * 
+     *
      * @return float
      */
     public function getSubTotal()
@@ -118,7 +118,7 @@ class Price
 
     /**
      * Discount per unit
-     * 
+     *
      * @return float
      */
     public function getDiscount()
@@ -146,7 +146,7 @@ class Price
 
     /**
      * (List x Quantity) - (Discount x Quantity)
-     * 
+     *
      * @param float $total
      */
     public function setTotal($total)
@@ -156,7 +156,7 @@ class Price
 
     /**
      * Tax included per unit
-     * 
+     *
      * @return float
      */
     public function getTaxIncluded()
@@ -175,7 +175,7 @@ class Price
 
     /**
      * Shipping cost per unit (not included in total)
-     * 
+     *
      * @return float
      */
     public function getShipping()

--- a/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/Order/SingleItem.php
+++ b/tests/Zoop/Shard/Test/Serializer/TestAsset/Document/Order/SingleItem.php
@@ -16,7 +16,7 @@ class SingleItem extends AbstractItem
      * @ODM\String
      */
     protected $name;
-    
+
     /**
      * @ODM\EmbedOne(
      *      discriminatorField="type",
@@ -43,9 +43,9 @@ class SingleItem extends AbstractItem
     {
         $this->sku = $sku;
     }
-    
+
     /**
-     * 
+     *
      * @return string
      */
     public function getName()
@@ -54,7 +54,7 @@ class SingleItem extends AbstractItem
     }
 
     /**
-     * 
+     *
      * @param string $name
      */
     public function setName($name)

--- a/tests/Zoop/Shard/Test/Serializer/UnserializerTest.php
+++ b/tests/Zoop/Shard/Test/Serializer/UnserializerTest.php
@@ -119,16 +119,16 @@ class UnserializerTest extends BaseTest
             $data,
             'Zoop\Shard\Test\Serializer\TestAsset\Document\Order\Order'
         );
-        
+
         $this->assertTrue($order instanceof Order);
         $this->assertEquals('crimsonronin', $order->getName());
         $this->assertCount(2, $order->getItems());
-        
+
         $single = $order->getItems()[0];
         $this->assertTrue($single instanceof SingleItem);
         $this->assertEquals(150, $single->getPrice()->getWholesale());
         $this->assertTrue($single->getSku() instanceof PhysicalSku);
-        
+
         $bundle = $order->getItems()[1];
         $this->assertTrue($bundle instanceof Bundle);
         $this->assertEquals(10, $bundle->getPrice()->getWholesale());

--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -2,7 +2,7 @@
 
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
-         colors="false"
+         colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"


### PR DESCRIPTION
Fixed a bug when using EmbedOne with discriminator field/map eg.

``` php
/**
 * @ODM\EmbedOne(
 *      discriminatorField="type",
 *      discriminatorMap={
 *         "RecordLabel"    = "Zoop\Shard\Test\ODMCore\TestAsset\Document\RecordLabel",
 *         "Artist"         = "Zoop\Shard\Test\ODMCore\TestAsset\Document\Artist"
 *      }
 * )
 */
protected $license;
```
